### PR TITLE
Enable drag-based card resizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Statinis vieno failo HTML projektas, skirtas publikuoti per **GitHub Pages**.
 
 ## Funkcijos
 
-- Grupių kortelių dydį galima keisti mygtuku „📏 Kortelės“.
+- Grupių kortelių dydį galima keisti jas tempiant į šoną ir žemyn.
 - „sheet“ ir „embed“ tipo įrašai automatiškai rodo peržiūrą kortelėje.
 
 ## Licencija

--- a/index.html
+++ b/index.html
@@ -28,8 +28,8 @@
     .search input{ background:var(--panel); border:1px solid transparent; color:var(--text); padding:12px 14px 12px 40px; border-radius:12px; min-width: 240px; outline:none; box-shadow:var(--shadow); }
     .search svg{ position:absolute; left:12px; top:50%; transform:translateY(-50%); opacity:.6 }
     main{ padding:20px clamp(10px,2.2vw,24px); max-width:1500px; width:100%; margin:0 auto; flex:1; }
-    .grid{ display:grid; grid-template-columns: repeat(auto-fill,minmax(var(--group-width),1fr)); gap:16px }
-    .group{ background:var(--panel); border:1px solid rgba(255,255,255,.06); border-radius:18px; box-shadow:var(--shadow); display:flex; flex-direction:column; min-height:120px; overflow:hidden; }
+    .grid{ display:flex; flex-wrap:wrap; gap:16px; }
+    .group{ background:var(--panel); border:1px solid rgba(255,255,255,.06); border-radius:18px; box-shadow:var(--shadow); display:flex; flex-direction:column; min-height:120px; overflow:auto; resize:both; width:var(--group-width); }
     .group-header{ display:flex; align-items:center; justify-content:space-between; gap:8px; padding:14px; background:linear-gradient(180deg, rgba(255,255,255,.04), transparent) }
     .group-title{ display:flex; align-items:center; gap:10px }
     .dot{ width:12px; height:12px; border-radius:50% }
@@ -73,7 +73,6 @@
       <button id="addGroup" type="button">➕ Pridėti grupę</button>
       <button id="importBtn" class="btn-outline" type="button">⤒ Importuoti</button>
       <button id="exportBtn" class="btn-outline" type="button">⤓ Eksportuoti</button>
-      <button id="sizeBtn" class="btn" type="button">📏 Kortelės</button>
       <button id="themeBtn" class="btn" type="button">🌓 Tema</button>
     </div>
   </header>
@@ -97,10 +96,6 @@
     import: 'Importuoti',
     export: 'Eksportuoti',
     theme: 'Tema',
-    size: 'Kortelės',
-    sizeSmall: 'Mažos',
-    sizeMedium: 'Vidutinės',
-    sizeLarge: 'Didelės',
     openAll: 'Atverti visas',
     addItem: 'Pridėti įrašą',
     collapse: 'Sutraukti/Išskleisti',
@@ -128,15 +123,25 @@
 
   const STORAGE_KEY = 'ed_dashboard_lt_v1';
   const THEME_KEY = 'ed_dash_theme';
-  const SIZE_KEY = 'ed_dash_size';
   const groupsEl = document.getElementById('groups');
   const statsEl = document.getElementById('stats');
   const searchEl = document.getElementById('q');
-  const sizeBtn = document.getElementById('sizeBtn');
 
   const uid = () => Math.random().toString(36).slice(2,10);
 
   let state = load() || seed();
+
+  const ro = new ResizeObserver(entries => {
+    for (const entry of entries) {
+      const id = entry.target.dataset.id;
+      const g = state.groups.find(x => x.id === id);
+      if (g) {
+        g.w = Math.round(entry.contentRect.width);
+        g.h = Math.round(entry.contentRect.height);
+        persist();
+      }
+    }
+  });
 
   // Dialogai
   const groupDlg = document.createElement('dialog');
@@ -244,7 +249,8 @@
   /** @typedef {{id:string, name:string, color:string, collapsed?:boolean, items: Item[]}} Group */
   /** @typedef {{id:string, type:'link'|'sheet'|'embed', title:string, url:string, note?:string}} Item */
 
-  function save(){ localStorage.setItem(STORAGE_KEY, JSON.stringify(state)); render(); }
+  function persist(){ localStorage.setItem(STORAGE_KEY, JSON.stringify(state)); }
+  function save(){ persist(); render(); }
   function load(){ try{return JSON.parse(localStorage.getItem(STORAGE_KEY)||'');}catch(e){return null;} }
   function seed(){
     const data = { groups: [] };
@@ -266,12 +272,15 @@
   }
 
   function render(){
+    ro.disconnect();
     const q = (searchEl.value||'').toLowerCase().trim();
     groupsEl.innerHTML = '';
     state.groups.forEach((g)=>{
       const grp = document.createElement('section');
       grp.className = 'group';
       grp.dataset.id = g.id;
+      if(g.w) grp.style.width = g.w + 'px';
+      if(g.h) grp.style.height = g.h + 'px';
       grp.draggable = true;
       grp.addEventListener('dragstart', e=>{ e.dataTransfer.setData('text/group', g.id); grp.style.opacity = .5; });
       grp.addEventListener('dragend',   ()=>{ grp.style.opacity = 1; });
@@ -401,6 +410,7 @@
 
       grp.appendChild(itemsWrap);
       groupsEl.appendChild(grp);
+      ro.observe(grp);
     });
 
     const totalGroups = state.groups.length;
@@ -479,32 +489,17 @@
 
   function applyTheme(){ const theme = localStorage.getItem(THEME_KEY) || 'dark'; if(theme==='light') document.documentElement.classList.add('theme-light'); else document.documentElement.classList.remove('theme-light'); }
   function toggleTheme(){ const now = (localStorage.getItem(THEME_KEY)||'dark')==='dark' ? 'light':'dark'; localStorage.setItem(THEME_KEY, now); applyTheme(); }
-  function applySize(){
-    const size = localStorage.getItem(SIZE_KEY) || 'm';
-    const map = {s:'300px', m:'360px', l:'460px'};
-    document.documentElement.style.setProperty('--group-width', map[size]);
-    sizeBtn.textContent = `📏 ${T.size}: ${size==='s'?T.sizeSmall:size==='l'?T.sizeLarge:T.sizeMedium}`;
-  }
-  function toggleSize(){
-    const now = localStorage.getItem(SIZE_KEY) || 'm';
-    const next = now==='s'?'m':now==='m'?'l':'s';
-    localStorage.setItem(SIZE_KEY, next);
-    applySize();
-  }
-
   document.getElementById('addGroup').addEventListener('click', addGroup);
   document.getElementById('exportBtn').addEventListener('click', exportJson);
   document.getElementById('importBtn').addEventListener('click', ()=> document.getElementById('fileInput').click());
   document.getElementById('fileInput').addEventListener('change', (e)=>{ const f = e.target.files[0]; if(f) importJson(f); e.target.value=''; });
   document.getElementById('themeBtn').addEventListener('click', toggleTheme);
-  sizeBtn.addEventListener('click', toggleSize);
   searchEl.placeholder = T.searchPH;
   searchEl.addEventListener('input', render);
 
   function escapeHtml(str){ return String(str).replace(/[&<>\"]/g, s=>({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;"}[s])); }
 
   applyTheme();
-  applySize();
   render();
 
   // Papildoma diagnostika, jei vartotojas sako, kad mygtukai „neveikia“


### PR DESCRIPTION
## Summary
- allow groups to be resized by dragging; persist dimensions via `ResizeObserver`
- remove global size button and update README to mention drag resizing

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be7e311e248320ba0df72b9fbe4c34