### PR TITLE
Focus title field on item dialog open

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,6 +242,7 @@
       itemForm.addEventListener('submit', submit);
       itemCancel.addEventListener('click', cancel);
       itemDlg.showModal();
+      itemForm.title.focus();
     });
   }
 


### PR DESCRIPTION
## Summary
- focus item title field after opening item dialog for quicker data entry

## Testing
- `node -e "const fs=require('fs');const t=fs.readFileSync('index.html','utf8');console.log(/itemDlg\.showModal\(\);\s*\n\s*itemForm\.title\.focus\(\);/.test(t)?'focus ok':'focus missing');"`
- `node - <<'NODE'
const fs=require('fs');
const {JSDOM}=require('jsdom');
const html=fs.readFileSync('index.html','utf8');
const dom = new JSDOM(html,{runScripts:'dangerously',resources:'usable',pretendToBeVisual:true,url:'https://example.org', beforeParse(window){ window.ResizeObserver = class { observe(){} disconnect(){} }; }});
dom.window.addEventListener('load', () => {
  const dialogs = dom.window.document.querySelectorAll('dialog');
  const itemDlg = dialogs[1];
  const itemForm = itemDlg.querySelector('#itemForm');
  try{ itemDlg.showModal(); itemForm.title.focus(); console.log('active:', dom.window.document.activeElement.name); }
  catch(err){ console.error('dialog showModal unsupported', err.message); }
});
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68be8332d488832086bba7b8d264418b