### PR TITLE
Sąlyginis pločio atnaujinimas ResizeObserver'e

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,14 +143,14 @@
       if (g) {
         const w = Math.round(entry.contentRect.width / GRID) * GRID;
         const h = Math.round(entry.contentRect.height / GRID) * GRID;
-        entry.target.style.width = w + 'px';
         if (entry.target.dataset.resizing === '1') {
+          entry.target.style.width = w + 'px';
           entry.target.style.height = h + 'px';
+          g.w = w;
           g.h = h;
           g.resized = true;
+          persist();
         }
-        g.w = w;
-        persist();
       }
     }
   });


### PR DESCRIPTION
## Summary
- atnaujintas `ResizeObserver`, kad grupių plotis ir `g.w` keistųsi tik aktyvaus dydžio keitimo metu
- pašalintas nereikalingas pločio priskyrimas, paliekant CSS `--group-width` numatytąją reikšmę

## Testing
- `npm test` *(nesėkminga: nenustatytas `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68bedab27fb48320a9c1fa73325285ba