### PR TITLE
Hide link text and resize embeds

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,8 @@
     .item .actions{ display:flex; gap:6px }
     .favicon{ width:20px; height:20px; border-radius:4px; background:var(--muted); flex:0 0 20px; display:grid; place-items:center; font-size:10px; color:var(--subtext) }
     .embed{ border-radius:12px; overflow:hidden; border:1px solid rgba(255,255,255,.08); }
-    .embed iframe{ width:100%; height:400px; border:0; background:white }
+    /* Iframe aukštis koreguojamas pagal grupės plotį (16:9 santykis) */
+    .embed iframe{ width:100%; border:0; background:white; height:auto; aspect-ratio:16/9 }
     details summary{ cursor:pointer; list-style:none }
     details summary::-webkit-details-marker{ display:none }
     .empty{ border:1px dashed rgba(255,255,255,.15); border-radius:14px; padding:18px; text-align:center; color:var(--subtext); font-size:14px }
@@ -205,6 +206,7 @@
           g.h = h;
           g.resized = true;
           persist();
+          resizeEmbeds(entry.target);
         }
       }
     }
@@ -476,7 +478,7 @@
             ${favicon}
             <div class="meta">
               <div class="title">${escapeHtml(it.title||'(be pavadinimo)')}</div>
-              <div class="sub">${escapeHtml(it.url)}</div>
+              <div class="sub">${escapeHtml(it.note||'')}</div>
             </div>
             ${actionsHtml}`;
 
@@ -514,6 +516,18 @@
     statsEl.textContent = `${totalGroups} grupės • ${totalItems} įrašai`;
   }
 
+  /**
+   * Pritaiko iframe aukštį pagal tėvinio elemento plotį (16:9 santykis)
+   * @param {HTMLElement} root Grupės elementas
+   */
+  function resizeEmbeds(root){
+    if(!root) return;
+    root.querySelectorAll('.embed iframe').forEach(frame => {
+      const w = frame.parentElement.clientWidth;
+      frame.style.height = Math.round(w * 0.5625) + 'px';
+    });
+  }
+
   function previewItem(it, mount){
     const existing = mount.nextElementSibling;
     if(existing && existing.classList.contains('embed')){ existing.remove(); return; }
@@ -523,6 +537,7 @@
     if(it.type==='sheet'){ const conv = toSheetEmbed(it.url); if(conv) src = conv; }
     wrap.innerHTML = `<details open><summary>Rodyti/slėpti peržiūrą</summary><iframe src="${src}" loading="lazy" referrerpolicy="no-referrer"></iframe></details>`;
     mount.after(wrap);
+    resizeEmbeds(mount.closest('.group'));
   }
 
   async function addGroup(){


### PR DESCRIPTION
## Summary
- Only show item title and note, hiding raw URL text
- Resize embedded previews automatically when a group is resized

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf292fc5f08320bb1dbbc7b818bbac