### PR TITLE
Avoid CORS preflight in Sheets sync and clean up HTML escape

### DIFF
--- a/render.js
+++ b/render.js
@@ -78,7 +78,7 @@ export function toSheetEmbed(url) {
 
 function escapeHtml(str) {
   return String(str).replace(
-    /[&<>\"]/g,
+    /[&<>"]/g,
     (s) =>
       ({
         '&': '&amp;',

--- a/storage.js
+++ b/storage.js
@@ -24,7 +24,7 @@ export function sheetsSync(state, syncStatus, saveFn, renderFn) {
   async function send(action, payload) {
     const res = await fetch(SCRIPT_URL, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      // Jokios "Content-Type" antraštės – taip išvengiama CORS preflight
       body: JSON.stringify({ action, data: payload }),
     });
     if (!res.ok) throw new Error('HTTP ' + res.status);


### PR DESCRIPTION
## Summary
- drop explicit `Content-Type` in Google Sheets sync to avoid CORS preflight errors
- tidy HTML escape helper to satisfy ESLint

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c01e2f45a883209ffbb3ad2684fc5a