### PR TITLE
Add offline check and error details for Sheets sync

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -34,6 +34,11 @@ export function sheetsSync(state, syncStatus, saveFn, renderFn) {
   return {
     async export() {
       syncStatus.textContent = 'Sinchronizuojama…';
+      if (!navigator.onLine) {
+        syncStatus.textContent = 'Nėra ryšio';
+        alert('Nėra interneto ryšio');
+        return;
+      }
       try {
         await send('export', state);
         syncStatus.textContent = 'Baigta';
@@ -41,7 +46,7 @@ export function sheetsSync(state, syncStatus, saveFn, renderFn) {
       } catch (err) {
         syncStatus.textContent = 'Nepavyko';
         console.error('Sheets eksportas nepavyko', err);
-        alert('Sheets eksportas nepavyko');
+        alert('Eksportas nepavyko: ' + err.message);
       } finally {
         setTimeout(() => {
           syncStatus.textContent = '';
@@ -50,6 +55,11 @@ export function sheetsSync(state, syncStatus, saveFn, renderFn) {
     },
     async import() {
       syncStatus.textContent = 'Sinchronizuojama…';
+      if (!navigator.onLine) {
+        syncStatus.textContent = 'Nėra ryšio';
+        alert('Nėra interneto ryšio');
+        return;
+      }
       try {
         const res = await send('import');
         if (res && res.data) {


### PR DESCRIPTION
## Summary
- prevent Sheets export/import when offline and show Lithuanian alert
- display detailed export error message with error text

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c03ad4f7a48320bc869cbf2430296f