### PR TITLE
Disable Google Sheets sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Statinis vieno failo HTML projektas, skirtas publikuoti per **GitHub Pages**.
 
+> **Pastaba:** sinchronizavimas su Google Sheets šiuo metu išjungtas.
+
 ## Naudojimas
 
 1. Atidarykite [projekto puslapį](https://<user>.github.io/admin-dashboard/) GitHub Pages (pakeiskite `<user>` savo GitHub naudotojo vardu).
@@ -12,11 +14,12 @@ Statinis vieno failo HTML projektas, skirtas publikuoti per **GitHub Pages**.
 - Grupių kortelių dydį galima keisti jas tempiant į šoną ir žemyn.
 - „sheet“ ir „embed“ tipo įrašai automatiškai rodo peržiūrą kortelėje.
 - Embed peržiūros kortelę galima vertikaliai padidinti arba sumažinti.
-- Eksportas ir importas į Google Sheets per Apps Script "web app".
-- Sinchronizacijos būsena rodoma antraštėje.
+- Eksportas ir importas į Google Sheets per Apps Script "web app" (laikinai išjungta).
 - Redagavimo režimas: išjungus puslapis tampa statinis, įjungus galima keisti grupes ir įrašus.
 
 ## Smoke test
+
+Šie žingsniai aktualūs tik atnaujinus ir vėl įjungus Google Sheets sinchronizavimą.
 
 1. Apps Script faile sukurkite funkcijas `doPost(e)` su veiksmu `export`/`import` ir publikuokite kaip "web app". URL galite gauti paleidę žemiau esantį pavyzdį ir pasižiūrėję **Execution log** skiltį.
 
@@ -34,4 +37,3 @@ Statinis vieno failo HTML projektas, skirtas publikuoti per **GitHub Pages**.
 ## Licencija
 
 Projektas platinamas pagal [MIT licenciją](LICENSE).
-

--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-import { load, save, seed, sheetsSync } from './storage.js';
+import { load, save, seed } from './storage.js';
 import {
   render,
   updateEditingUI,
@@ -65,7 +65,7 @@ const I = {
 };
 
 const editBtn = document.getElementById('editBtn');
-const syncStatus = document.getElementById('syncStatus');
+// const syncStatus = document.getElementById('syncStatus'); // Sheets sync indikatorius (išjungta)
 const searchEl = document.getElementById('q');
 
 let state = load() || seed();
@@ -186,15 +186,14 @@ function importJson(file) {
   reader.readAsText(file);
 }
 
-const sheets = sheetsSync(state, syncStatus, () => save(state), renderAll);
+// Google Sheets sinchronizavimas laikinai išjungtas
+// const sheets = sheetsSync(state, syncStatus, () => save(state), renderAll);
 
 document.getElementById('addGroup').addEventListener('click', addGroup);
 document.getElementById('exportBtn').addEventListener('click', () => {
   exportJson();
-  sheets.export();
 });
 document.getElementById('importBtn').addEventListener('click', () => {
-  sheets.import();
   document.getElementById('fileInput').click();
 });
 document.getElementById('fileInput').addEventListener('change', (e) => {


### PR DESCRIPTION
## Summary
- temporarily disable Google Sheets synchronization by removing `sheetsSync` usage
- note in README that Sheets sync is currently disabled

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c0590be45c8320bdc1a69435cc7c6b