### PR TITLE
Refine item action button spacing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -31,6 +31,7 @@ main{ padding:20px clamp(10px,2.2vw,24px); max-width:1500px; width:100%; margin:
 .group-header h2{ margin:0; font-size:16px }
 .group-actions{ display:flex; align-items:center; gap:4px }
 .group-actions button{ padding:4px }
+.item .actions button{ padding:4px; min-width:32px; }
 .items{ display:grid; grid-template-columns:1fr; gap:6px; padding:8px; }
 .item{ background:var(--card); border:1px solid rgba(255,255,255,.06); border-radius:10px; padding:8px; display:flex; gap:8px; align-items:center; box-shadow:var(--shadow) }
 .item.dragging{ opacity:.45 }


### PR DESCRIPTION
## Summary
- ensure item action buttons have consistent padding and minimum width to avoid expanding cards

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c060129d7083209baf4d08f862ef1e