### PR TITLE
Fix item menu clipping in admin dashboard

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -24,14 +24,14 @@ button:hover, .btn:hover{ transform: translateY(-1px); background:var(--muted) }
 .search svg{ position:absolute; left:12px; top:50%; transform:translateY(-50%); opacity:.6 }
 main{ padding:20px clamp(10px,2.2vw,24px); max-width:1500px; width:100%; margin:0 auto; flex:1; }
 .grid{ display:flex; flex-wrap:wrap; gap:16px; }
-.group{ background:var(--panel); border:1px solid rgba(255,255,255,.06); border-radius:16px; box-shadow:var(--shadow); display:flex; flex-direction:column; min-height:100px; overflow:auto; resize:both; width:var(--group-width); }
+  .group{ background:var(--panel); border:1px solid rgba(255,255,255,.06); border-radius:16px; box-shadow:var(--shadow); display:flex; flex-direction:column; min-height:100px; overflow:visible; resize:both; width:var(--group-width); }
 .group-header{ display:flex; align-items:center; justify-content:space-between; gap:6px; padding:10px; background:linear-gradient(180deg, rgba(255,255,255,.04), transparent) }
 .group-title{ display:flex; align-items:center; gap:8px }
 .dot{ width:12px; height:12px; border-radius:50% }
 .group-header h2{ margin:0; font-size:16px }
 .group-actions{ display:flex; align-items:center; gap:4px }
 .group-actions button{ padding:4px }
-.items{ display:grid; grid-template-columns:1fr; gap:6px; padding:8px; }
+  .items{ display:grid; grid-template-columns:1fr; gap:6px; padding:8px; overflow:auto; }
 .item{ background:var(--card); border:1px solid rgba(255,255,255,.06); border-radius:10px; padding:8px; display:flex; gap:8px; align-items:center; box-shadow:var(--shadow) }
 .item.dragging{ opacity:.45 }
 .item .meta{ flex:1; min-width:0; text-decoration:none; color:inherit; display:block }
@@ -39,7 +39,7 @@ main{ padding:20px clamp(10px,2.2vw,24px); max-width:1500px; width:100%; margin:
 .item .meta .sub{ font-size:11px; color:var(--subtext); overflow:hidden; text-overflow:ellipsis; white-space:nowrap }
 .item .actions{ margin-left:auto; position:relative; }
 .item .actions>button{ padding:4px; }
-.item .actions .menu{ position:absolute; right:0; top:100%; margin-top:4px; display:flex; flex-direction:column; gap:4px; background:var(--panel); border:1px solid rgba(255,255,255,.06); border-radius:8px; padding:4px; box-shadow:var(--shadow); }
+  .item .actions .menu{ position:absolute; right:0; top:100%; margin-top:4px; display:flex; flex-direction:column; gap:4px; background:var(--panel); border:1px solid rgba(255,255,255,.06); border-radius:8px; padding:4px; box-shadow:var(--shadow); z-index:10; }
 .item .actions .menu button{ width:100%; justify-content:flex-start; padding:6px 8px; box-shadow:none; }
 .item .actions .menu[hidden]{ display:none; }
 .favicon{ width:16px; height:16px; border-radius:4px; background:var(--muted); flex:0 0 16px; display:grid; place-items:center; color:var(--subtext) }


### PR DESCRIPTION
## Summary
- make group containers show overflow content
- enable scrolling within items lists
- ensure item action menus appear above other elements

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c084b9134c8320a9bd675cc10f2de0