### PR TITLE
feat: allow custom item icons

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,6 +32,7 @@ const T = {
   renameGroup: 'Pervadinti grupę',
   itemTitle: 'Pavadinimas',
   itemUrl: 'URL',
+  itemIcon: 'Piktogramos URL (nebūtina)',
   itemNote: 'Pastaba (nebūtina)',
   sheetTip:
     'Patarimas: Google Sheets turi būti „Publish to web“ arba bendrinamas.',
@@ -145,6 +146,7 @@ async function addItem(gid) {
     title: data.title,
     url: data.url,
     note: data.note,
+    iconUrl: data.iconUrl,
   });
   save(state);
   renderAll();
@@ -165,6 +167,7 @@ async function editItem(gid, iid) {
   it.title = data.title;
   it.url = data.url;
   it.note = data.note;
+  it.iconUrl = data.iconUrl;
   save(state);
   renderAll();
 }

--- a/forms.js
+++ b/forms.js
@@ -59,6 +59,7 @@ export function itemFormDialog(T, data = {}) {
       </label>
       <label>${T.itemTitle}<br><input name="title" required></label>
       <label>${T.itemUrl}<br><input name="url" type="url" required></label>
+      <label>${T.itemIcon}<br><input name="iconUrl" type="url" placeholder="https://example.com/icon.png"></label>
       <label>${T.itemNote}<br><textarea name="note" rows="2"></textarea></label>
       <p class="error" id="itemErr"></p>
       <menu>
@@ -73,6 +74,7 @@ export function itemFormDialog(T, data = {}) {
     form.type.value = data.type || 'link';
     form.title.value = data.title || '';
     form.url.value = data.url || '';
+    form.iconUrl.value = data.iconUrl || '';
     form.note.value = data.note || '';
 
     function cleanup() {
@@ -86,6 +88,7 @@ export function itemFormDialog(T, data = {}) {
       const formData = Object.fromEntries(new FormData(form));
       formData.title = formData.title.trim();
       formData.url = formData.url.trim();
+      formData.iconUrl = formData.iconUrl.trim();
       formData.note = formData.note.trim();
       if (!formData.title || !formData.url) {
         err.textContent = T.required;
@@ -96,6 +99,14 @@ export function itemFormDialog(T, data = {}) {
       } catch {
         err.textContent = T.invalidUrl;
         return;
+      }
+      if (formData.iconUrl) {
+        try {
+          new URL(formData.iconUrl);
+        } catch {
+          err.textContent = T.invalidUrl;
+          return;
+        }
       }
       resolve(formData);
       cleanup();

--- a/render.js
+++ b/render.js
@@ -296,8 +296,9 @@ export function render(state, editing, T, I, handlers, saveFn) {
           });
         }
 
-        const favicon =
-          it.type === 'link'
+        const favicon = it.iconUrl
+          ? `<img class="favicon" alt="" src="${it.iconUrl}">`
+          : it.type === 'link'
             ? `<img class="favicon" alt="" src="${toFavicon(it.url)}">`
             : `<div class="favicon">${it.type === 'sheet' ? I.table : I.puzzle}</div>`;
 
@@ -319,9 +320,16 @@ export function render(state, editing, T, I, handlers, saveFn) {
             </div>`
           : '';
         card.innerHTML = `${favicon}${metaHtml}${actionsHtml}`;
-        if (it.type === 'link')
-          card.querySelector('img.favicon')?.addEventListener('error', (e) => {
-            e.target.outerHTML = `<div class="favicon">${I.globe}</div>`;
+        const imgFav = card.querySelector('img.favicon');
+        if (imgFav)
+          imgFav.addEventListener('error', (e) => {
+            const fallback =
+              it.type === 'sheet'
+                ? I.table
+                : it.type === 'embed'
+                ? I.puzzle
+                : I.globe;
+            e.target.outerHTML = `<div class="favicon">${fallback}</div>`;
           });
 
         card.addEventListener('click', (e) => {

--- a/storage.js
+++ b/storage.js
@@ -2,7 +2,15 @@ const STORAGE_KEY = 'ed_dashboard_lt_v1';
 
 export function load() {
   try {
-    return JSON.parse(localStorage.getItem(STORAGE_KEY) || '');
+    const data = JSON.parse(localStorage.getItem(STORAGE_KEY) || '');
+    if (data && Array.isArray(data.groups)) {
+      data.groups.forEach((g) =>
+        g.items?.forEach((it) => {
+          if (!('iconUrl' in it)) it.iconUrl = '';
+        }),
+      );
+    }
+    return data;
   } catch (e) {
     return null;
   }


### PR DESCRIPTION
## Summary
- add optional `iconUrl` to item form and translation
- render custom icons with graceful fallback when loading fails
- ensure `iconUrl` is persisted in storage and item editing

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1070bf4a48320bb8ba9dde96a952e