### PR TITLE
feat: keep item menus visible at edges

### DIFF
--- a/render.js
+++ b/render.js
@@ -239,6 +239,8 @@ export function render(state, editing, T, I, handlers, saveFn) {
 
     const itemsWrap = document.createElement('div');
     itemsWrap.className = 'items';
+    const itemsScroll = document.createElement('div');
+    itemsScroll.className = 'items-scroll';
 
     const filteredItems = g.items.filter((i) => {
       if (!q) return true;
@@ -251,7 +253,7 @@ export function render(state, editing, T, I, handlers, saveFn) {
       const empty = document.createElement('div');
       empty.className = 'empty';
       empty.textContent = q ? T.noMatches : T.empty;
-      itemsWrap.appendChild(empty);
+      itemsScroll.appendChild(empty);
     } else {
       filteredItems.forEach((it) => {
         const card = document.createElement('div');
@@ -376,10 +378,11 @@ export function render(state, editing, T, I, handlers, saveFn) {
           }
         });
 
-        itemsWrap.appendChild(card);
+        itemsScroll.appendChild(card);
       });
     }
 
+    itemsWrap.appendChild(itemsScroll);
     grp.appendChild(itemsWrap);
     groupsEl.appendChild(grp);
     ro.observe(grp);

--- a/styles.css
+++ b/styles.css
@@ -31,7 +31,8 @@ main{ padding:20px clamp(10px,2.2vw,24px); max-width:1500px; width:100%; margin:
 .group-header h2{ margin:0; font-size:16px }
 .group-actions{ display:flex; align-items:center; gap:4px }
 .group-actions button{ padding:4px }
-  .items{ display:grid; grid-template-columns:1fr; gap:6px; padding:8px; overflow:auto; }
+  .items{ overflow:visible; }
+  .items-scroll{ display:grid; grid-template-columns:1fr; gap:6px; padding:8px; overflow:auto; }
 .item{ background:var(--card); border:1px solid rgba(255,255,255,.06); border-radius:10px; padding:8px; display:flex; gap:8px; align-items:center; box-shadow:var(--shadow) }
 .item.dragging{ opacity:.45 }
 .item .meta{ flex:1; min-width:0; text-decoration:none; color:inherit; display:block }


### PR DESCRIPTION
## Summary
- move item list scrolling to inner `.items-scroll` container
- allow outer `.items` wrapper to be overflow-visible so menus aren't clipped

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c1118212508320803f04a134d97940