### PR TITLE
feat: add floating menu positioning

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -43,6 +43,8 @@ main{ padding:20px clamp(10px,2.2vw,24px); max-width:1500px; width:100%; margin:
   .item .actions .menu{ position:absolute; right:0; top:100%; margin-top:4px; display:flex; flex-direction:column; gap:4px; background:var(--panel); border:1px solid rgba(255,255,255,.06); border-radius:8px; padding:4px; box-shadow:var(--shadow); z-index:10; }
 .item .actions .menu button{ width:100%; justify-content:flex-start; padding:6px 8px; box-shadow:none; }
 .item .actions .menu[hidden]{ display:none; }
+.floating-menu{ display:flex; flex-direction:column; gap:4px; background:var(--panel); border:1px solid rgba(255,255,255,.06); border-radius:8px; padding:4px; box-shadow:var(--shadow); position:fixed; z-index:1000; }
+.floating-menu button{ width:100%; justify-content:flex-start; padding:6px 8px; box-shadow:none; }
 .favicon{ width:16px; height:16px; border-radius:4px; background:var(--muted); flex:0 0 16px; display:grid; place-items:center; color:var(--subtext) }
 .favicon svg{ width:100%; height:100%; }
 .embed{ border-radius:12px; overflow:hidden; border:1px solid rgba(255,255,255,.08); resize:vertical; min-height:120px; }


### PR DESCRIPTION
## Summary
- attach edit actions to a floating menu placed on `document.body`
- position floating menu near the trigger and close on outside click or Escape
- style new `.floating-menu` class with fixed positioning and high z-index

## Testing
- `npm test` (fails: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1185ce2a08320aa39bc414af397d5