### PR TITLE
Fix group overflow to re-enable group resizing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -24,7 +24,7 @@ button:hover, .btn:hover{ transform: translateY(-1px); background:var(--muted) }
 .search svg{ position:absolute; left:12px; top:50%; transform:translateY(-50%); opacity:.6 }
 main{ padding:20px clamp(10px,2.2vw,24px); max-width:1500px; width:100%; margin:0 auto; flex:1; }
 .grid{ display:flex; flex-wrap:wrap; gap:16px; }
-  .group{ background:var(--panel); border:1px solid rgba(255,255,255,.06); border-radius:16px; box-shadow:var(--shadow); display:flex; flex-direction:column; min-height:100px; overflow:visible; resize:both; width:var(--group-width); }
+  .group{ background:var(--panel); border:1px solid rgba(255,255,255,.06); border-radius:16px; box-shadow:var(--shadow); display:flex; flex-direction:column; min-height:100px; overflow:auto; resize:both; width:var(--group-width); }
 .group-header{ display:flex; align-items:center; justify-content:space-between; gap:6px; padding:10px; background:linear-gradient(180deg, rgba(255,255,255,.04), transparent) }
 .group-title{ display:flex; align-items:center; gap:8px }
 .dot{ width:12px; height:12px; border-radius:50% }


### PR DESCRIPTION
## Summary
- fix `.group` CSS overflow to `auto` so resize handles work again
- keep `.items` overflow visible to prevent inner clipping

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c11aeab3008320a7804e9538a5df87