### PR TITLE
feat: sync resize across selected groups

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -182,6 +182,10 @@ main {
   width: var(--group-width);
   max-width: 100%;
 }
+
+.group.selected {
+  outline: 2px solid var(--accent);
+}
 .group-header {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- allow shift-click to toggle group selection
- propagate resize changes to all selected groups
- outline selected groups for visual feedback

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c173a16ad88320b6877e7d31d2b714