### PR TITLE
Increase resize grid snap to 40px

### DIFF
--- a/render.js
+++ b/render.js
@@ -5,7 +5,7 @@ let floatingMenu;
 // Holds references to currently shift-selected groups
 let selectedGroups = [];
 
-const GRID = 20;
+const GRID = 40;
 
 const ro = new ResizeObserver((entries) => {
   for (const entry of entries) {


### PR DESCRIPTION
## Summary
- coarsen group resize snapping to 40px grid for easier alignment

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1757287848320a84ce538ef416a9f