### PR TITLE
fix: keep link size outside edit mode

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -280,14 +280,14 @@ main {
 }
 .item .meta .title {
   font-weight: 700;
-  font-size: 13px;
+  font-size: 1rem; /* keep size consistent after leaving edit mode */
   color: var(--text);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 .item .meta .sub {
-  font-size: 11px;
+  font-size: 0.875rem; /* match default input size */
   color: var(--subtext);
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
## Summary
- fix link text shrinking when leaving edit mode by switching to rem-based font sizes

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1a28dcde0832093ef6e5c229b648b