### PR TITLE
Validate HTTP protocol in item form URL

### DIFF
--- a/forms.js
+++ b/forms.js
@@ -143,7 +143,11 @@ export function itemFormDialog(T, data = {}) {
         return;
       }
       try {
-        new URL(formData.url);
+        const u = new URL(formData.url);
+        if (!/^https?:$/.test(u.protocol)) {
+          err.textContent = T.invalidUrl;
+          return;
+        }
       } catch {
         err.textContent = T.invalidUrl;
         return;


### PR DESCRIPTION
## Summary
- ensure item form URLs only use http or https protocols

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c24fde78288320a35b0d879f5e0374