### PR TITLE
feat: add theme icons and button update

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,8 +2,6 @@ import { load, save, seed } from './storage.js';
 import {
   render,
   updateEditingUI,
-  applyTheme,
-  toggleTheme,
   toSheetEmbed,
 } from './render.js';
 import {
@@ -22,6 +20,8 @@ const T = {
   import: 'Importuoti',
   export: 'Eksportuoti',
   theme: 'Tema',
+  toDark: 'Perjungti į tamsią temą',
+  toLight: 'Perjungti į šviesią temą',
   openAll: 'Atverti visas',
   addItem: 'Pridėti įrašą',
   editGroup: 'Redaguoti grupę',
@@ -60,6 +60,7 @@ const T = {
 const editBtn = document.getElementById('editBtn');
 // const syncStatus = document.getElementById('syncStatus'); // Sheets sync indikatorius (išjungta)
 const searchEl = document.getElementById('q');
+const themeBtn = document.getElementById('themeBtn');
 
 let state = load() || seed();
 let editing = false;
@@ -236,6 +237,28 @@ function importJson(file) {
   reader.readAsText(file);
 }
 
+function applyTheme() {
+  const theme = localStorage.getItem('ed_dash_theme') || 'dark';
+  if (theme === 'light') {
+    document.documentElement.classList.add('theme-light');
+    themeBtn.innerHTML = `${I.sun} <span>${T.theme}</span>`;
+    themeBtn.setAttribute('aria-label', T.toDark);
+  } else {
+    document.documentElement.classList.remove('theme-light');
+    themeBtn.innerHTML = `${I.moon} <span>${T.theme}</span>`;
+    themeBtn.setAttribute('aria-label', T.toLight);
+  }
+}
+
+function toggleTheme() {
+  const now =
+    (localStorage.getItem('ed_dash_theme') || 'dark') === 'dark'
+      ? 'light'
+      : 'dark';
+  localStorage.setItem('ed_dash_theme', now);
+  applyTheme();
+}
+
 // Google Sheets sinchronizavimas laikinai išjungtas
 // const sheets = sheetsSync(state, syncStatus, () => save(state), renderAll);
 
@@ -270,7 +293,7 @@ document.getElementById('fileInput').addEventListener('change', (e) => {
   if (f) importJson(f);
   e.target.value = '';
 });
-document.getElementById('themeBtn').addEventListener('click', toggleTheme);
+themeBtn.addEventListener('click', toggleTheme);
 editBtn.addEventListener('click', () => {
   editing = !editing;
   updateUI();

--- a/icons.js
+++ b/icons.js
@@ -39,4 +39,8 @@ export const I = {
   clock:
     '<svg class="icon" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>',
   user: '<svg class="icon" viewBox="0 0 24 24"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>',
+  sun:
+    '<svg class="icon" viewBox="0 0 24 24"><circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="M4.93 4.93l1.41 1.41"/><path d="M17.66 17.66l1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="M6.34 17.66l-1.41 1.41"/><path d="M19.07 4.93l-1.41 1.41"/></svg>',
+  moon:
+    '<svg class="icon" viewBox="0 0 24 24"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg>',
 };


### PR DESCRIPTION
## Summary
- add `sun` and `moon` SVG icons
- update theme functions to swap icon and `aria-label`

## Testing
- `npm test` (fails: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c262349e748320900b450614e746f6