### PR TITLE
feat: add hover effects for groups and items

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -213,6 +213,9 @@ main {
   resize: both;
   width: var(--group-width);
   max-width: 100%;
+  transition:
+    0.2s ease background,
+    0.2s ease transform;
 }
 
 .group.selected {
@@ -267,9 +270,17 @@ main {
   gap: 8px;
   align-items: center;
   box-shadow: var(--shadow);
+  transition:
+    0.2s ease background,
+    0.2s ease transform;
 }
 .item.dragging {
   opacity: 0.45;
+}
+.group:hover,
+.item:hover {
+  background: var(--muted);
+  transform: translateY(-2px);
 }
 .item .meta {
   flex: 1;


### PR DESCRIPTION
## Summary
- add shared hover styles for groups and items
- smooth hover animation using existing transition values

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2686a16408320ba8d1b1171dd4b6d