### PR TITLE
feat: add collapsible groups

### DIFF
--- a/app.js
+++ b/app.js
@@ -23,6 +23,8 @@ const T = {
   toDark: 'Perjungti į tamsią temą',
   toLight: 'Perjungti į šviesią temą',
   openAll: 'Atverti visas',
+  collapse: 'Suskleisti',
+  expand: 'Išskleisti',
   addItem: 'Pridėti įrašą',
   editGroup: 'Redaguoti grupę',
   editChart: 'Redaguoti grafiką',
@@ -86,6 +88,7 @@ function renderAll() {
       editGroup,
       editItem,
       editChart,
+      toggleCollapse,
       confirmDialog: (msg) => confirmDlg(T, msg),
     },
     () => save(state),
@@ -149,6 +152,14 @@ async function editChart(gid) {
     g.h = parsed.h + 56;
     g.resized = true;
   }
+  save(state);
+  renderAll();
+}
+
+function toggleCollapse(gid) {
+  const g = state.groups.find((x) => x.id === gid);
+  if (!g) return;
+  g.collapsed = !g.collapsed;
   save(state);
   renderAll();
 }

--- a/render.js
+++ b/render.js
@@ -226,6 +226,7 @@ export function render(state, editing, T, I, handlers, saveFn) {
       h.className = 'group-header';
       h.innerHTML = `
         <div class="group-title">
+          <button type="button" class="toggle" data-collapse title="${g.collapsed ? T.expand : T.collapse}" aria-label="${g.collapsed ? T.expand : T.collapse}">${g.collapsed ? I.arrowDown : I.arrowUp}</button>
           <span class="dot" style="background:${g.color || '#6ee7b7'}"></span>
           <h2 title="Tempkite, kad perrikiuotumėte" class="handle">${escapeHtml(g.name || '')}</h2>
         </div>
@@ -243,6 +244,10 @@ export function render(state, editing, T, I, handlers, saveFn) {
       h.addEventListener('click', (e) => {
         const btn = e.target.closest('button');
         if (!btn) return;
+        if (btn.dataset.collapse !== undefined) {
+          handlers.toggleCollapse(g.id);
+          return;
+        }
         const act = btn.dataset.act;
         if (act === 'edit') return handlers.editChart(g.id);
         if (act === 'del') {
@@ -278,6 +283,7 @@ export function render(state, editing, T, I, handlers, saveFn) {
       emb.style.resize = 'none';
       emb.innerHTML = `<iframe src="${g.url}" loading="lazy" referrerpolicy="no-referrer"></iframe>`;
       grp.appendChild(emb);
+      if (g.collapsed) grp.classList.add('collapsed');
       groupsEl.appendChild(grp);
       ro.observe(grp);
       resizeEmbeds(grp);
@@ -340,6 +346,7 @@ export function render(state, editing, T, I, handlers, saveFn) {
     h.className = 'group-header';
     h.innerHTML = `
         <div class="group-title">
+          <button type="button" class="toggle" data-collapse title="${g.collapsed ? T.expand : T.collapse}" aria-label="${g.collapsed ? T.expand : T.collapse}">${g.collapsed ? I.arrowDown : I.arrowUp}</button>
           <span class="dot" style="background:${g.color || '#6ee7b7'}"></span>
           <h2 title="Tempkite, kad perrikiuotumėte" class="handle">${escapeHtml(g.name)}</h2>
         </div>
@@ -359,6 +366,10 @@ export function render(state, editing, T, I, handlers, saveFn) {
     h.addEventListener('click', (e) => {
       const btn = e.target.closest('button');
       if (!btn) return;
+      if (btn.dataset.collapse !== undefined) {
+        handlers.toggleCollapse(g.id);
+        return;
+      }
       const act = btn.dataset.act;
       if (act === 'add') return handlers.addItem(g.id);
       if (act === 'edit') return handlers.editGroup(g.id);
@@ -587,6 +598,7 @@ export function render(state, editing, T, I, handlers, saveFn) {
 
     itemsWrap.appendChild(itemsScroll);
     grp.appendChild(itemsWrap);
+    if (g.collapsed) grp.classList.add('collapsed');
     groupsEl.appendChild(grp);
     ro.observe(grp);
     resizeEmbeds(grp);

--- a/styles.css
+++ b/styles.css
@@ -251,6 +251,15 @@ main {
 .group-actions button {
   padding: 4px;
 }
+
+.group-header .toggle {
+  padding: 4px;
+}
+
+.group.collapsed .items,
+.group.collapsed .embed {
+  display: none;
+}
 .items {
   overflow: visible;
 }


### PR DESCRIPTION
## Summary
- add collapse/expand translations and state handler
- render group headers with collapse toggle
- hide items/embeds when group is collapsed and add styling

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c2adeb658483209b58961c927932ac