### PR TITLE
feat: add notes dialog

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,14 +1,11 @@
 import { load, save, seed } from './storage.js';
-import {
-  render,
-  updateEditingUI,
-  toSheetEmbed,
-} from './render.js';
+import { render, updateEditingUI, toSheetEmbed } from './render.js';
 import {
   groupFormDialog,
   itemFormDialog,
   chartFormDialog,
   confirmDialog as confirmDlg,
+  notesDialog,
 } from './forms.js';
 import { I } from './icons.js';
 
@@ -20,6 +17,7 @@ const T = {
   import: 'Importuoti',
   export: 'Eksportuoti',
   theme: 'Tema',
+  notes: 'Pastabos',
   toDark: 'Perjungti į tamsią temą',
   toLight: 'Perjungti į šviesią temą',
   openAll: 'Atverti visas',
@@ -63,6 +61,7 @@ const editBtn = document.getElementById('editBtn');
 // const syncStatus = document.getElementById('syncStatus'); // Sheets sync indikatorius (išjungta)
 const searchEl = document.getElementById('q');
 const themeBtn = document.getElementById('themeBtn');
+const notesBtn = document.getElementById('notesBtn');
 
 let state = load() || seed();
 let editing = false;
@@ -308,6 +307,12 @@ themeBtn.addEventListener('click', toggleTheme);
 editBtn.addEventListener('click', () => {
   editing = !editing;
   updateUI();
+});
+notesBtn.setAttribute('aria-label', T.notes);
+notesBtn.addEventListener('click', async () => {
+  const current = localStorage.getItem('notes') || '';
+  const res = await notesDialog(T, current);
+  if (res !== null) localStorage.setItem('notes', res);
 });
 searchEl.placeholder = T.searchPH;
 searchEl.addEventListener('input', renderAll);

--- a/forms.js
+++ b/forms.js
@@ -219,6 +219,46 @@ export function chartFormDialog(T, data = {}) {
   });
 }
 
+export function notesDialog(T, text = '') {
+  return new Promise((resolve) => {
+    const dlg = document.createElement('dialog');
+    dlg.innerHTML = `<form method="dialog" id="notesForm">
+      <label>${T.notes}<br><textarea name="note" rows="8"></textarea></label>
+      <menu>
+        <button type="button" data-act="cancel">${T.cancel}</button>
+        <button type="submit" class="btn-accent">${T.save}</button>
+      </menu>
+    </form>`;
+    document.body.appendChild(dlg);
+    const form = dlg.querySelector('form');
+    const cancel = form.querySelector('[data-act="cancel"]');
+    form.note.value = text || '';
+
+    function cleanup() {
+      form.removeEventListener('submit', submit);
+      cancel.removeEventListener('click', close);
+      dlg.remove();
+    }
+
+    function submit(e) {
+      e.preventDefault();
+      resolve(form.note.value.trim());
+      cleanup();
+    }
+
+    function close() {
+      resolve(null);
+      cleanup();
+    }
+
+    form.addEventListener('submit', submit);
+    cancel.addEventListener('click', close);
+    dlg.addEventListener('cancel', close);
+    dlg.showModal();
+    form.note.focus();
+  });
+}
+
 export function confirmDialog(T, msg) {
   return new Promise((resolve) => {
     const dlg = document.createElement('dialog');

--- a/index.html
+++ b/index.html
@@ -1,44 +1,109 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="lt">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>SMPS admin skydelis</title>
-  <link rel="stylesheet" href="styles.css">
-</head>
-<body>
-  <header>
-    <div class="title">
-      <svg width="28" height="28" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M12 3l7 4v10l-7 4-7-4V7l7-4z" stroke="currentColor" stroke-width="1.5"/><path d="M12 7l3.5 2v6L12 17l-3.5-2V9L12 7z" stroke="currentColor" stroke-width="1.5"/></svg>
-      <h1>SMPS admin skydelis</h1>
-      <span class="badge" id="stats"></span>
-    </div>
-    <div class="controls">
-      <div class="search">
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M21 21l-4.35-4.35" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><circle cx="11" cy="11" r="7.25" stroke="currentColor" stroke-width="1.5"/></svg>
-        <input id="q" placeholder="Paieška nuorodose…"/>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SMPS admin skydelis</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <div class="title">
+        <svg
+          width="28"
+          height="28"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
+        >
+          <path
+            d="M12 3l7 4v10l-7 4-7-4V7l7-4z"
+            stroke="currentColor"
+            stroke-width="1.5"
+          />
+          <path
+            d="M12 7l3.5 2v6L12 17l-3.5-2V9L12 7z"
+            stroke="currentColor"
+            stroke-width="1.5"
+          />
+        </svg>
+        <h1>SMPS admin skydelis</h1>
+        <span class="badge" id="stats"></span>
       </div>
-      <button id="editBtn" class="btn-outline" type="button"></button>
-      <div id="addMenu" class="dropdown" style="display:none">
-        <button id="addBtn" type="button"></button>
-        <div id="addMenuList" class="dropdown-list">
-          <button id="addGroup" type="button"></button>
-          <button id="addChart" type="button"></button>
+      <div class="controls">
+        <div class="search">
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M21 21l-4.35-4.35"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+            />
+            <circle
+              cx="11"
+              cy="11"
+              r="7.25"
+              stroke="currentColor"
+              stroke-width="1.5"
+            />
+          </svg>
+          <input id="q" placeholder="Paieška nuorodose…" />
         </div>
+        <button id="editBtn" class="btn-outline" type="button"></button>
+        <div id="addMenu" class="dropdown" style="display: none">
+          <button id="addBtn" type="button"></button>
+          <div id="addMenuList" class="dropdown-list">
+            <button id="addGroup" type="button"></button>
+            <button id="addChart" type="button"></button>
+          </div>
+        </div>
+        <button
+          id="importBtn"
+          class="btn-outline"
+          type="button"
+          style="display: none"
+        >
+          <svg class="icon" viewBox="0 0 24 24">
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+            <polyline points="7 10 12 15 17 10" />
+            <line x1="12" y1="15" x2="12" y2="3" /></svg
+          ><span>Importuoti</span>
+        </button>
+        <button
+          id="exportBtn"
+          class="btn-outline"
+          type="button"
+          style="display: none"
+        >
+          <svg class="icon" viewBox="0 0 24 24">
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+            <polyline points="17 8 12 3 7 8" />
+            <line x1="12" y1="3" x2="12" y2="15" /></svg
+          ><span>Eksportuoti</span>
+        </button>
+        <button id="notesBtn">📝</button>
+        <button id="themeBtn" class="btn" type="button">
+          <svg class="icon" viewBox="0 0 24 24">
+            <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" /></svg
+          ><span>Tema</span>
+        </button>
+        <span id="syncStatus" aria-live="polite"></span>
       </div>
-      <button id="importBtn" class="btn-outline" type="button" style="display:none"><svg class="icon" viewBox="0 0 24 24"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg><span>Importuoti</span></button>
-      <button id="exportBtn" class="btn-outline" type="button" style="display:none"><svg class="icon" viewBox="0 0 24 24"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg><span>Eksportuoti</span></button>
-      <button id="themeBtn" class="btn" type="button"><svg class="icon" viewBox="0 0 24 24"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg><span>Tema</span></button>
-      <span id="syncStatus" aria-live="polite"></span>
-    </div>
-  </header>
+    </header>
 
-  <main>
-    <div id="groups" class="grid" aria-live="polite"></div>
-  </main>
+    <main>
+      <div id="groups" class="grid" aria-live="polite"></div>
+    </main>
 
-  <input type="file" id="fileInput" accept="application/json" hidden />
+    <input type="file" id="fileInput" accept="application/json" hidden />
 
-<script src="app.js" type="module"></script>
-</body>
+    <script src="app.js" type="module"></script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- add notes button in header
- allow editing and saving notes in a dialog

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2b00290dc8320be416a22a12f37ee