### PR TITLE
Add note card option

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,6 +14,7 @@ const T = {
   add: 'Pridėti',
   addGroup: 'Pridėti grupę',
   addChart: 'Pridėti grafiką',
+  addNote: 'Pridėti pastabas',
   import: 'Importuoti',
   export: 'Eksportuoti',
   theme: 'Tema',
@@ -61,9 +62,11 @@ const editBtn = document.getElementById('editBtn');
 // const syncStatus = document.getElementById('syncStatus'); // Sheets sync indikatorius (išjungta)
 const searchEl = document.getElementById('q');
 const themeBtn = document.getElementById('themeBtn');
-const notesBtn = document.getElementById('notesBtn');
 
 let state = load() || seed();
+if (!('notes' in state)) {
+  state.notes = localStorage.getItem('notes') || '';
+}
 let editing = false;
 
 const uid = () => Math.random().toString(36).slice(2, 10);
@@ -87,6 +90,7 @@ function renderAll() {
       editGroup,
       editItem,
       editChart,
+      editNotes,
       toggleCollapse,
       confirmDialog: (msg) => confirmDlg(T, msg),
     },
@@ -135,6 +139,14 @@ async function addChart() {
     h: parsed.h ? parsed.h + 56 : undefined,
     resized: !!parsed.h,
   });
+  save(state);
+  renderAll();
+}
+
+async function editNotes() {
+  const res = await notesDialog(T, state.notes || '');
+  if (res === null) return;
+  state.notes = res;
   save(state);
   renderAll();
 }
@@ -292,6 +304,10 @@ document.getElementById('addChart').addEventListener('click', () => {
   hideAddMenu();
   addChart();
 });
+document.getElementById('addNote').addEventListener('click', () => {
+  hideAddMenu();
+  editNotes();
+});
 document.getElementById('exportBtn').addEventListener('click', () => {
   exportJson();
 });
@@ -307,12 +323,6 @@ themeBtn.addEventListener('click', toggleTheme);
 editBtn.addEventListener('click', () => {
   editing = !editing;
   updateUI();
-});
-notesBtn.setAttribute('aria-label', T.notes);
-notesBtn.addEventListener('click', async () => {
-  const current = localStorage.getItem('notes') || '';
-  const res = await notesDialog(T, current);
-  if (res !== null) localStorage.setItem('notes', res);
 });
 searchEl.placeholder = T.searchPH;
 searchEl.addEventListener('input', renderAll);

--- a/index.html
+++ b/index.html
@@ -62,6 +62,7 @@
           <div id="addMenuList" class="dropdown-list">
             <button id="addGroup" type="button"></button>
             <button id="addChart" type="button"></button>
+            <button id="addNote" type="button"></button>
           </div>
         </div>
         <button
@@ -88,7 +89,6 @@
             <line x1="12" y1="3" x2="12" y2="15" /></svg
           ><span>Eksportuoti</span>
         </button>
-        <button id="notesBtn">📝</button>
         <button id="themeBtn" class="btn" type="button">
           <svg class="icon" viewBox="0 0 24 24">
             <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" /></svg

--- a/render.js
+++ b/render.js
@@ -164,6 +164,45 @@ export function render(state, editing, T, I, handlers, saveFn) {
 
   const q = (searchEl.value || '').toLowerCase().trim();
   groupsEl.innerHTML = '';
+  if (state.notes) {
+    const noteGrp = document.createElement('section');
+    noteGrp.className = 'group';
+    noteGrp.dataset.id = 'notes';
+    noteGrp.dataset.resizing = '0';
+    noteGrp.style.resize = editing ? 'both' : 'none';
+    const h = document.createElement('div');
+    h.className = 'group-header';
+    h.innerHTML = `
+        <div class="group-title">
+          <span class="dot" style="background:#fef08a"></span>
+          <h2>${T.notes}</h2>
+        </div>
+        ${
+          editing
+            ? `<div class="group-actions">
+          <button type="button" title="${T.edit}" aria-label="${T.edit}" data-act="edit">${I.pencil}</button>
+        </div>`
+            : ''
+        }`;
+    h.addEventListener('click', (e) => {
+      const btn = e.target.closest('button');
+      if (!btn) return;
+      if (btn.dataset.act === 'edit') handlers.editNotes();
+    });
+    noteGrp.appendChild(h);
+    const itemsWrap = document.createElement('div');
+    itemsWrap.className = 'items';
+    const itemsScroll = document.createElement('div');
+    itemsScroll.className = 'items-scroll';
+    const p = document.createElement('p');
+    p.style.whiteSpace = 'pre-wrap';
+    p.textContent = state.notes;
+    itemsScroll.appendChild(p);
+    itemsWrap.appendChild(itemsScroll);
+    noteGrp.appendChild(itemsWrap);
+    groupsEl.appendChild(noteGrp);
+    ro.observe(noteGrp);
+  }
   state.groups.forEach((g) => {
     if (g.type === 'chart') {
       const grp = document.createElement('section');
@@ -622,9 +661,11 @@ export function updateEditingUI(editing, T, I, renderFn) {
   const addBtn = document.getElementById('addBtn');
   const addGroup = document.getElementById('addGroup');
   const addChart = document.getElementById('addChart');
+  const addNote = document.getElementById('addNote');
   if (addBtn) addBtn.innerHTML = `${I.plus} <span>${T.add}</span>`;
   if (addGroup) addGroup.innerHTML = `${I.plus} ${T.addGroup}`;
   if (addChart) addChart.innerHTML = `${I.chart} ${T.addChart}`;
+  if (addNote) addNote.innerHTML = `${I.plus} ${T.addNote}`;
   renderFn();
 }
 

--- a/storage.js
+++ b/storage.js
@@ -10,6 +10,7 @@ export function load() {
           if (!('icon' in it)) it.icon = '';
         }),
       );
+      if (typeof data.notes !== 'string') data.notes = '';
     }
     return data;
   } catch (e) {
@@ -22,7 +23,7 @@ export function save(state) {
 }
 
 export function seed() {
-  const data = { groups: [] };
+  const data = { groups: [], notes: '' };
   save(data);
   return data;
 }


### PR DESCRIPTION
## Summary
- allow creating a notes card from the add menu
- render saved notes as a card similar to groups
- persist notes alongside groups

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2b5e490188320b5e4dc130e7a4ed9