### PR TITLE
feat: add note formatting options

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,6 +19,8 @@ const T = {
   export: 'Eksportuoti',
   theme: 'Tema',
   notes: 'Pastabos',
+  noteSize: 'Šrifto dydis (px)',
+  notePadding: 'Paraštės (px)',
   toDark: 'Perjungti į tamsią temą',
   toLight: 'Perjungti į šviesią temą',
   openAll: 'Atverti visas',
@@ -64,9 +66,8 @@ const searchEl = document.getElementById('q');
 const themeBtn = document.getElementById('themeBtn');
 
 let state = load() || seed();
-if (!('notes' in state)) {
-  state.notes = localStorage.getItem('notes') || '';
-}
+if (!('notes' in state)) state.notes = localStorage.getItem('notes') || '';
+if (!('notesOpts' in state)) state.notesOpts = { size: 16, padding: 8 };
 let editing = false;
 
 const uid = () => Math.random().toString(36).slice(2, 10);
@@ -144,9 +145,13 @@ async function addChart() {
 }
 
 async function editNotes() {
-  const res = await notesDialog(T, state.notes || '');
+  const res = await notesDialog(
+    T,
+    { text: state.notes || '', ...state.notesOpts },
+  );
   if (res === null) return;
-  state.notes = res;
+  state.notes = res.text;
+  state.notesOpts = { size: res.size, padding: res.padding };
   save(state);
   renderAll();
 }

--- a/forms.js
+++ b/forms.js
@@ -219,11 +219,16 @@ export function chartFormDialog(T, data = {}) {
   });
 }
 
-export function notesDialog(T, text = '') {
+export function notesDialog(
+  T,
+  data = { text: '', size: 16, padding: 8 },
+) {
   return new Promise((resolve) => {
     const dlg = document.createElement('dialog');
     dlg.innerHTML = `<form method="dialog" id="notesForm">
       <label>${T.notes}<br><textarea name="note" rows="8"></textarea></label>
+      <label>${T.noteSize}<br><input name="size" type="number" min="10" max="48"></label>
+      <label>${T.notePadding}<br><input name="padding" type="number" min="0" max="100"></label>
       <menu>
         <button type="button" data-act="cancel">${T.cancel}</button>
         <button type="submit" class="btn-accent">${T.save}</button>
@@ -232,7 +237,9 @@ export function notesDialog(T, text = '') {
     document.body.appendChild(dlg);
     const form = dlg.querySelector('form');
     const cancel = form.querySelector('[data-act="cancel"]');
-    form.note.value = text || '';
+    form.note.value = data.text || '';
+    form.size.value = data.size || 16;
+    form.padding.value = data.padding || 8;
 
     function cleanup() {
       form.removeEventListener('submit', submit);
@@ -242,7 +249,11 @@ export function notesDialog(T, text = '') {
 
     function submit(e) {
       e.preventDefault();
-      resolve(form.note.value.trim());
+      resolve({
+        text: form.note.value.trim(),
+        size: parseInt(form.size.value, 10) || 16,
+        padding: parseInt(form.padding.value, 10) || 8,
+      });
       cleanup();
     }
 

--- a/render.js
+++ b/render.js
@@ -196,6 +196,8 @@ export function render(state, editing, T, I, handlers, saveFn) {
     itemsScroll.className = 'items-scroll';
     const p = document.createElement('p');
     p.style.whiteSpace = 'pre-wrap';
+    p.style.padding = (state.notesOpts?.padding ?? 8) + 'px';
+    p.style.fontSize = (state.notesOpts?.size ?? 16) + 'px';
     p.textContent = state.notes;
     itemsScroll.appendChild(p);
     itemsWrap.appendChild(itemsScroll);

--- a/storage.js
+++ b/storage.js
@@ -11,6 +11,12 @@ export function load() {
         }),
       );
       if (typeof data.notes !== 'string') data.notes = '';
+      if (
+        !data.notesOpts ||
+        typeof data.notesOpts.size !== 'number' ||
+        typeof data.notesOpts.padding !== 'number'
+      )
+        data.notesOpts = { size: 16, padding: 8 };
     }
     return data;
   } catch (e) {
@@ -23,7 +29,7 @@ export function save(state) {
 }
 
 export function seed() {
-  const data = { groups: [], notes: '' };
+  const data = { groups: [], notes: '', notesOpts: { size: 16, padding: 8 } };
   save(data);
   return data;
 }


### PR DESCRIPTION
## Summary
- add configurable font size and padding for notes
- persist note styling preferences
- render notes with applied padding and larger text

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2b94075288320ba2c7d799cad3c85