### PR TITLE
Fix search icon overlap

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -179,7 +179,6 @@ button:hover,
   position: relative;
 }
 .search input {
-  padding: 12px 14px 12px 40px;
   border-radius: 12px;
   min-width: 240px;
   box-shadow: var(--shadow);
@@ -484,6 +483,9 @@ input::placeholder,
 textarea::placeholder {
   color: var(--subtext);
   opacity: 0.8;
+}
+.search input {
+  padding: 12px 14px 12px 40px;
 }
 @media (max-width: 620px) {
   .controls {


### PR DESCRIPTION
## Summary
- prevent search input text from overlapping its icon by reapplying padding after global input styles

## Testing
- `npx prettier styles.css --write`
- `npm run lint`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d238efc88320a7d4a9d5661949d3