### PR TITLE
feat: add placeholder for page title

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Statinis vieno failo HTML projektas, skirtas publikuoti per **GitHub Pages**.
 - Eksportas ir importas į Google Sheets per Apps Script "web app" (laikinai išjungta).
 - Redagavimo režimas: išjungus puslapis tampa statinis, įjungus galima keisti grupes ir įrašus.
 - Puslapio pavadinimą ir ikoną galima redaguoti ir jie išsaugomi naršyklėje.
+- Jei pavadinimas tuščias redagavimo režime, rodomas pilkas užrašas „Įveskite pavadinimą“.
 
 ## Smoke test
 

--- a/styles.css
+++ b/styles.css
@@ -76,6 +76,17 @@ header {
   font-size: clamp(18px, 3.5vw, 24px);
   letter-spacing: 0.2px;
 }
+
+/* Placeholder and focus style for editable page title */
+.title h1[contenteditable='true']:empty::before {
+  content: 'Įveskite pavadinimą';
+  color: var(--subtext);
+}
+
+.title h1[contenteditable='true']:focus {
+  outline: 1px dashed var(--muted);
+  padding: 2px 4px;
+}
 .page-icon {
   width: 28px;
   height: 28px;


### PR DESCRIPTION
## Summary
- show "Įveskite pavadinimą" placeholder when page title empty
- document page title placeholder behavior in README

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`
- `npx prettier --write README.md styles.css`


------
https://chatgpt.com/codex/tasks/task_e_68c2dd6b06bc83209b96a9aef1e4a2b6