### PR TITLE
Add localized search label for accessibility

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,6 +12,7 @@ import { I } from './icons.js';
 
 const T = {
   searchPH: 'Paieška nuorodose…',
+  searchLabel: 'Paieška',
   add: 'Pridėti',
   addGroup: 'Pridėti grupę',
   addChart: 'Pridėti grafiką',
@@ -67,6 +68,7 @@ const T = {
 const editBtn = document.getElementById('editBtn');
 // const syncStatus = document.getElementById('syncStatus'); // Sheets sync indikatorius (išjungta)
 const searchEl = document.getElementById('q');
+const searchLabelEl = document.getElementById('searchLabel');
 const themeBtn = document.getElementById('themeBtn');
 const colorBtn = document.getElementById('colorBtn');
 const pageTitleEl = document.getElementById('pageTitle');
@@ -455,6 +457,8 @@ editBtn.addEventListener('click', () => {
   editing = !editing;
   updateUI();
 });
+if (searchLabelEl) searchLabelEl.textContent = T.searchLabel;
+searchEl.setAttribute('aria-label', T.searchLabel);
 searchEl.placeholder = T.searchPH;
 searchEl.addEventListener('input', renderAll);
 

--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
               stroke-width="1.5"
             />
           </svg>
+          <label for="q" id="searchLabel" class="sr-only">Paieška</label>
           <input id="q" placeholder="Paieška nuorodose…" />
         </div>
         <!-- Fallback labels so buttons are visible before JS initializes -->

--- a/styles.css
+++ b/styles.css
@@ -59,6 +59,17 @@ body {
   display: flex;
   flex-direction: column;
 }
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
 header {
   position: sticky;
   top: 0;


### PR DESCRIPTION
## Summary
- add visually hidden search label using translation strings
- provide `sr-only` style and localize search text

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c39acdd35c832089d5bb75dea5ebcf