### PR TITLE
Add theme selection dialog with customization option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Statinis vieno failo HTML projektas, skirtas publikuoti per **GitHub Pages**.
 - Redagavimo režimas: išjungus puslapis tampa statinis, įjungus galima keisti grupes ir įrašus.
 - Puslapio pavadinimą ir ikoną galima redaguoti ir jie išsaugomi naršyklėje.
 - Jei pavadinimas tuščias redagavimo režime, rodomas pilkas užrašas „Įveskite pavadinimą“.
-- Spalvų temą galima keisti paspaudus **Spalvos** – parinktys išsaugomos `localStorage`.
+- Spalvų temą galima keisti paspaudus **Tema** – parinktys išsaugomos `localStorage`.
 - Pastabų kortelę galima perkelti tarp grupių drag-and-drop būdu.
 - Spalvų meniu turi mygtuką **Atstatyti**, grąžinantį numatytas spalvas.
 

--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ import {
   confirmDialog as confirmDlg,
   notesDialog,
   themeDialog,
+  themeSelectDialog,
 } from './forms.js';
 import { I } from './icons.js';
 
@@ -20,7 +21,7 @@ const T = {
   import: 'Importuoti',
   export: 'Eksportuoti',
   theme: 'Tema',
-  colors: 'Spalvos',
+  customize: 'Tinkinti',
   notes: 'Pastabos',
   noteTitle: 'Pastabų pavadinimas',
   noteSize: 'Šrifto dydis (px)',
@@ -400,17 +401,22 @@ function toggleTheme() {
   applyTheme();
 }
 
-async function editColors() {
-  const themes = getThemes();
+async function selectTheme() {
   const currId = localStorage.getItem('ed_dash_theme') || 'dark';
-  const currTheme =
-    currId === 'custom'
-      ? themes.find((t) => t.id === 'custom')
-      : baseThemes.find((t) => t.id === currId);
-  const res = await themeDialog(T, { ...currTheme.vars });
+  const res = await themeSelectDialog(T, baseThemes, currId);
   if (!res) return;
-  localStorage.setItem('ed_dash_theme_custom', JSON.stringify(res));
-  localStorage.setItem('ed_dash_theme', 'custom');
+  if (res === 'customize') {
+    const currTheme =
+      currId === 'custom'
+        ? getThemes().find((t) => t.id === 'custom')
+        : baseThemes.find((t) => t.id === currId);
+    const custom = await themeDialog(T, { ...currTheme.vars });
+    if (!custom) return;
+    localStorage.setItem('ed_dash_theme_custom', JSON.stringify(custom));
+    localStorage.setItem('ed_dash_theme', 'custom');
+  } else {
+    localStorage.setItem('ed_dash_theme', res);
+  }
   applyTheme();
 }
 
@@ -453,9 +459,9 @@ document.getElementById('fileInput').addEventListener('change', (e) => {
   e.target.value = '';
 });
 themeBtn.addEventListener('click', toggleTheme);
-colorBtn.innerHTML = `🎨 <span>${T.colors}</span>`;
-colorBtn.setAttribute('aria-label', T.colors);
-colorBtn.addEventListener('click', editColors);
+colorBtn.innerHTML = `🎨 <span>${T.theme}</span>`;
+colorBtn.setAttribute('aria-label', T.theme);
+colorBtn.addEventListener('click', selectTheme);
 editBtn.addEventListener('click', () => {
   editing = !editing;
   updateUI();

--- a/forms.js
+++ b/forms.js
@@ -302,6 +302,59 @@ export function notesDialog(
   });
 }
 
+export function themeSelectDialog(T, themes = [], current = 'dark') {
+  return new Promise((resolve) => {
+    const prevFocus = document.activeElement;
+    const options = themes
+      .map((t) => {
+        const v = t.vars;
+        const name = t.id.charAt(0).toUpperCase() + t.id.slice(1);
+        const sel = t.id === current ? ' aria-current="true"' : '';
+        return `<button type="button" data-id="${t.id}" class="theme-opt"${sel}><span style="display:inline-block;width:24px;height:24px;background:${v.bg};border:4px solid ${v.accent};margin-right:8px;"></span>${name}</button>`;
+      })
+      .join('');
+    const dlg = document.createElement('dialog');
+    dlg.innerHTML = `<div class="theme-list">${options}</div><menu><button type="button" data-act="custom">${T.customize}</button><button type="button" data-act="cancel">${T.cancel}</button></menu>`;
+    dlg.setAttribute('aria-modal', 'true');
+    document.body.appendChild(dlg);
+    const list = dlg.querySelector('.theme-list');
+    const cancel = dlg.querySelector('[data-act="cancel"]');
+    const custom = dlg.querySelector('[data-act="custom"]');
+
+    function cleanup() {
+      list.removeEventListener('click', choose);
+      cancel.removeEventListener('click', close);
+      custom.removeEventListener('click', customize);
+      dlg.remove();
+      prevFocus?.focus();
+    }
+
+    function choose(e) {
+      const btn = e.target.closest('button[data-id]');
+      if (!btn) return;
+      resolve(btn.dataset.id);
+      cleanup();
+    }
+
+    function close() {
+      resolve(null);
+      cleanup();
+    }
+
+    function customize() {
+      resolve('customize');
+      cleanup();
+    }
+
+    list.addEventListener('click', choose);
+    cancel.addEventListener('click', close);
+    custom.addEventListener('click', customize);
+    dlg.addEventListener('cancel', close);
+    dlg.showModal();
+    list.querySelector('button')?.focus();
+  });
+}
+
 export function themeDialog(T, data = {}) {
   return new Promise((resolve) => {
     const fields = [

--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
           ><span>Tema</span>
         </button>
         <button id="colorBtn" class="btn-outline" type="button">
-          🎨 <span>Spalvos</span>
+          🎨 <span>Tema</span>
         </button>
         <span id="syncStatus" role="status" aria-live="polite"></span>
       </div>


### PR DESCRIPTION
## Summary
- Add `themeSelectDialog` to display base themes with preview and optional customize button
- Replace color editor with `selectTheme` saving chosen theme and invoking `applyTheme`
- Rename color button to “Tema” and update documentation

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5663fe9e48320a9beb5dbc434cde9