### PR TITLE
Separate theme and color controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,9 +78,18 @@
             <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" /></svg
           ><span>Tema</span>
         </button>
-        <button id="colorBtn" class="btn-outline" type="button">
-          🎨 <span>Tema</span>
-        </button>
+          <div id="colorMenu" class="dropdown">
+            <button id="colorBtn" class="btn-outline" type="button">
+              🎨 <span>Spalva</span>
+            </button>
+            <div id="colorMenuList" class="dropdown-list">
+              <button data-color="emerald" type="button">Žalsva</button>
+              <button data-color="sky" type="button">Mėlyna</button>
+              <button data-color="rose" type="button">Rožinė</button>
+              <button data-color="amber" type="button">Gintarinė</button>
+              <button data-color="violet" type="button">Violetinė</button>
+            </div>
+          </div>
         <span id="syncStatus" role="status" aria-live="polite"></span>
       </div>
     </header>

--- a/styles.css
+++ b/styles.css
@@ -4,9 +4,9 @@
   --muted: #1b2530;
   --text: #e6edf3;
   --subtext: #9fb0c0;
-  --accent: #6ee7b7;
-  --accent2: #3dd6a6;
-  --btn-accent-text: #0a0f14;
+  --accent: #10b981;
+  --accent2: #059669;
+  --btn-accent-text: #ffffff;
   --danger: #ff6b6b;
   --danger2: #e24a4a;
   --btn-danger-text: #ffffff;
@@ -22,15 +22,37 @@
   --muted: #e9eef3;
   --text: #0c1116;
   --subtext: #4a5a6a;
-  --accent: #2563eb;
-  --accent2: #1d4ed8;
-  --btn-accent-text: #ffffff;
   --danger: #d83a3a;
   --danger2: #b92424;
   --btn-danger-text: #ffffff;
   --ok: #0ea5e9;
   --card: #ffffff;
   --shadow: 0 10px 24px rgba(7, 14, 22, 0.08);
+}
+
+.color-emerald:root {
+  --accent: #10b981;
+  --accent2: #059669;
+}
+
+.color-sky:root {
+  --accent: #0ea5e9;
+  --accent2: #0284c7;
+}
+
+.color-rose:root {
+  --accent: #f472b6;
+  --accent2: #ec4899;
+}
+
+.color-amber:root {
+  --accent: #f59e0b;
+  --accent2: #d97706;
+}
+
+.color-violet:root {
+  --accent: #a78bfa;
+  --accent2: #7c3aed;
 }
 *,
 *::before,


### PR DESCRIPTION
## Summary
- limit theme toggle to light/dark and add color palette dropdown with five modern accents
- add persistent color themes and CSS variables for accents

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c56bd845b08320ae680c968f546c0d