### PR TITLE
Remove color menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Statinis vieno failo HTML projektas, skirtas publikuoti per **GitHub Pages**.
 - Jei pavadinimas tuščias redagavimo režime, rodomas pilkas užrašas „Įveskite pavadinimą“.
 - Spalvų temą galima keisti paspaudus **Tema** – parinktys išsaugomos `localStorage`.
 - Pastabų kortelę galima perkelti tarp grupių drag-and-drop būdu.
-- Spalvų meniu turi mygtuką **Atstatyti**, grąžinantį numatytas spalvas.
 
 ## Smoke test
 

--- a/app.js
+++ b/app.js
@@ -19,7 +19,6 @@ const T = {
   import: 'Importuoti',
   export: 'Eksportuoti',
   theme: 'Tema',
-  color: 'Spalva',
   customize: 'Tinkinti',
   notes: 'Pastabos',
   noteTitle: 'Pastabų pavadinimas',
@@ -72,9 +71,6 @@ const editBtn = document.getElementById('editBtn');
 const searchEl = document.getElementById('q');
 const searchLabelEl = document.getElementById('searchLabel');
 const themeBtn = document.getElementById('themeBtn');
-const colorBtn = document.getElementById('colorBtn');
-const colorMenuList = document.getElementById('colorMenuList');
-const colorMenu = document.getElementById('colorMenu');
 const pageTitleEl = document.getElementById('pageTitle');
 const pageIconEl = document.getElementById('pageIcon');
 
@@ -86,7 +82,6 @@ if (!('notesBox' in state)) state.notesBox = { w: 0, h: 0 };
 if (!('notesPos' in state)) state.notesPos = 0;
 if (!state.title) state.title = DEFAULT_TITLE;
 let editing = false;
-
 
 pageTitleEl.textContent = state.title;
 pageIconEl.textContent = state.icon || '';
@@ -322,22 +317,6 @@ function toggleTheme() {
   applyTheme();
 }
 
-// Galimos spalvų schemos; pridėkite savo jei reikia
-const colorThemes = ['emerald', 'sky', 'rose', 'amber', 'violet'];
-
-function applyColor() {
-  const color = localStorage.getItem('ed_dash_color') || 'emerald';
-  document.documentElement.classList.remove(
-    ...colorThemes.map((c) => `color-${c}`),
-  );
-  document.documentElement.classList.add(`color-${color}`);
-}
-
-function setColor(color) {
-  localStorage.setItem('ed_dash_color', color);
-  applyColor();
-}
-
 // Google Sheets sinchronizavimas laikinai išjungtas
 // const sheets = sheetsSync(state, syncStatus, () => save(state), renderAll);
 
@@ -377,25 +356,6 @@ document.getElementById('fileInput').addEventListener('change', (e) => {
   e.target.value = '';
 });
 themeBtn.addEventListener('click', toggleTheme);
-colorBtn.innerHTML = `🎨 <span>${T.color}</span>`;
-colorBtn.setAttribute('aria-label', T.color);
-const colorOptions = document.querySelectorAll('#colorMenuList button');
-function hideColorMenu() {
-  colorMenuList.style.display = 'none';
-}
-colorBtn.addEventListener('click', () => {
-  colorMenuList.style.display =
-    colorMenuList.style.display === 'flex' ? 'none' : 'flex';
-});
-document.addEventListener('click', (e) => {
-  if (!colorMenu.contains(e.target)) hideColorMenu();
-});
-colorOptions.forEach((btn) => {
-  btn.addEventListener('click', () => {
-    setColor(btn.dataset.color);
-    hideColorMenu();
-  });
-});
 editBtn.addEventListener('click', () => {
   editing = !editing;
   updateUI();
@@ -406,7 +366,6 @@ searchEl.placeholder = T.searchPH;
 searchEl.addEventListener('input', renderAll);
 
 applyTheme();
-applyColor();
 updateUI();
 
 window.addEventListener('error', (e) => {

--- a/index.html
+++ b/index.html
@@ -40,7 +40,9 @@
           <input id="q" placeholder="Paieška nuorodose…" />
         </div>
         <!-- Fallback labels so buttons are visible before JS initializes -->
-        <button id="editBtn" class="btn-outline" type="button">Redaguoti</button>
+        <button id="editBtn" class="btn-outline" type="button">
+          Redaguoti
+        </button>
         <div id="addMenu" class="dropdown" style="display: none">
           <button id="addBtn" type="button">＋ Pridėti</button>
           <div id="addMenuList" class="dropdown-list">
@@ -78,18 +80,6 @@
             <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" /></svg
           ><span>Tema</span>
         </button>
-          <div id="colorMenu" class="dropdown">
-            <button id="colorBtn" class="btn-outline" type="button">
-              🎨 <span>Spalva</span>
-            </button>
-            <div id="colorMenuList" class="dropdown-list">
-              <button data-color="emerald" type="button">Žalsva</button>
-              <button data-color="sky" type="button">Mėlyna</button>
-              <button data-color="rose" type="button">Rožinė</button>
-              <button data-color="amber" type="button">Gintarinė</button>
-              <button data-color="violet" type="button">Violetinė</button>
-            </div>
-          </div>
         <span id="syncStatus" role="status" aria-live="polite"></span>
       </div>
     </header>

--- a/styles.css
+++ b/styles.css
@@ -29,31 +29,6 @@
   --card: #ffffff;
   --shadow: 0 10px 24px rgba(7, 14, 22, 0.08);
 }
-
-.color-emerald:root {
-  --accent: #10b981;
-  --accent2: #059669;
-}
-
-.color-sky:root {
-  --accent: #0ea5e9;
-  --accent2: #0284c7;
-}
-
-.color-rose:root {
-  --accent: #f472b6;
-  --accent2: #ec4899;
-}
-
-.color-amber:root {
-  --accent: #f59e0b;
-  --accent2: #d97706;
-}
-
-.color-violet:root {
-  --accent: #a78bfa;
-  --accent2: #7c3aed;
-}
 *,
 *::before,
 *::after {


### PR DESCRIPTION
## Summary
- remove unused accent color menu from the header
- drop JavaScript and CSS related to color switching
- update README to reflect menu removal

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6ae3b1bc48320a8476e5c67548617