### PR TITLE
Remove color menu and dropdown styles

### DIFF
--- a/app.js
+++ b/app.js
@@ -72,9 +72,6 @@ const editBtn = document.getElementById('editBtn');
 const searchEl = document.getElementById('q');
 const searchLabelEl = document.getElementById('searchLabel');
 const themeBtn = document.getElementById('themeBtn');
-const colorBtn = document.getElementById('colorBtn');
-const colorMenuList = document.getElementById('colorMenuList');
-const colorMenu = document.getElementById('colorMenu');
 const pageTitleEl = document.getElementById('pageTitle');
 const pageIconEl = document.getElementById('pageIcon');
 
@@ -86,7 +83,6 @@ if (!('notesBox' in state)) state.notesBox = { w: 0, h: 0 };
 if (!('notesPos' in state)) state.notesPos = 0;
 if (!state.title) state.title = DEFAULT_TITLE;
 let editing = false;
-
 
 pageTitleEl.textContent = state.title;
 pageIconEl.textContent = state.icon || '';
@@ -332,12 +328,6 @@ function applyColor() {
   );
   document.documentElement.classList.add(`color-${color}`);
 }
-
-function setColor(color) {
-  localStorage.setItem('ed_dash_color', color);
-  applyColor();
-}
-
 // Google Sheets sinchronizavimas laikinai išjungtas
 // const sheets = sheetsSync(state, syncStatus, () => save(state), renderAll);
 
@@ -377,25 +367,6 @@ document.getElementById('fileInput').addEventListener('change', (e) => {
   e.target.value = '';
 });
 themeBtn.addEventListener('click', toggleTheme);
-colorBtn.innerHTML = `🎨 <span>${T.color}</span>`;
-colorBtn.setAttribute('aria-label', T.color);
-const colorOptions = document.querySelectorAll('#colorMenuList button');
-function hideColorMenu() {
-  colorMenuList.style.display = 'none';
-}
-colorBtn.addEventListener('click', () => {
-  colorMenuList.style.display =
-    colorMenuList.style.display === 'flex' ? 'none' : 'flex';
-});
-document.addEventListener('click', (e) => {
-  if (!colorMenu.contains(e.target)) hideColorMenu();
-});
-colorOptions.forEach((btn) => {
-  btn.addEventListener('click', () => {
-    setColor(btn.dataset.color);
-    hideColorMenu();
-  });
-});
 editBtn.addEventListener('click', () => {
   editing = !editing;
   updateUI();

--- a/index.html
+++ b/index.html
@@ -40,10 +40,12 @@
           <input id="q" placeholder="Paieška nuorodose…" />
         </div>
         <!-- Fallback labels so buttons are visible before JS initializes -->
-        <button id="editBtn" class="btn-outline" type="button">Redaguoti</button>
-        <div id="addMenu" class="dropdown" style="display: none">
+        <button id="editBtn" class="btn-outline" type="button">
+          Redaguoti
+        </button>
+        <div id="addMenu" style="display: none">
           <button id="addBtn" type="button">＋ Pridėti</button>
-          <div id="addMenuList" class="dropdown-list">
+          <div id="addMenuList">
             <button id="addGroup" type="button">＋ Pridėti grupę</button>
             <button id="addChart" type="button">📈 Pridėti grafiką</button>
             <button id="addNote" type="button">＋ Pridėti pastabas</button>
@@ -78,18 +80,6 @@
             <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" /></svg
           ><span>Tema</span>
         </button>
-          <div id="colorMenu" class="dropdown">
-            <button id="colorBtn" class="btn-outline" type="button">
-              🎨 <span>Spalva</span>
-            </button>
-            <div id="colorMenuList" class="dropdown-list">
-              <button data-color="emerald" type="button">Žalsva</button>
-              <button data-color="sky" type="button">Mėlyna</button>
-              <button data-color="rose" type="button">Rožinė</button>
-              <button data-color="amber" type="button">Gintarinė</button>
-              <button data-color="violet" type="button">Violetinė</button>
-            </div>
-          </div>
         <span id="syncStatus" role="status" aria-live="polite"></span>
       </div>
     </header>

--- a/styles.css
+++ b/styles.css
@@ -148,37 +148,6 @@ header {
   align-items: center;
 }
 
-.dropdown {
-  position: relative;
-}
-
-.dropdown-list {
-  position: absolute;
-  top: 100%;
-  right: 0;
-  display: none;
-  flex-direction: column;
-  background: var(--panel);
-  border: 1px solid var(--muted);
-  border-radius: 12px;
-  padding: 4px;
-  margin-top: 4px;
-  box-shadow: var(--shadow);
-  z-index: 10;
-}
-
-.dropdown-list button {
-  background: transparent;
-  border: none;
-  box-shadow: none;
-  padding: 8px 12px;
-  border-radius: 8px;
-  justify-content: flex-start;
-}
-
-.dropdown-list button:hover {
-  background: var(--muted);
-}
 button,
 .btn {
   border: 1px solid transparent;


### PR DESCRIPTION
## Summary
- remove unused color menu markup and dropdown classes
- drop color menu logic from app.js and clean up unused setColor
- delete dropdown-related styles

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b572270483208a727d6b0926075b