### PR TITLE
chore: throttle resize persistence

### DIFF
--- a/render.js
+++ b/render.js
@@ -5,6 +5,9 @@ let floatingMenu;
 // Holds references to currently shift-selected groups
 let selectedGroups = [];
 
+// Tracks if state changes need to be persisted
+let pendingPersist = false;
+
 const GRID = 40;
 
 const ro = new ResizeObserver((entries) => {
@@ -41,7 +44,7 @@ const ro = new ResizeObserver((entries) => {
         }
       });
 
-      persist();
+      pendingPersist = true;
     }
   }
 });
@@ -52,6 +55,14 @@ document.addEventListener('mouseup', () => {
     g.style.minWidth = '';
     g.style.minHeight = '';
   });
+  if (pendingPersist) {
+    requestAnimationFrame(() => {
+      if (pendingPersist) {
+        persist();
+        pendingPersist = false;
+      }
+    });
+  }
 });
 
 document.addEventListener('click', (e) => {


### PR DESCRIPTION
## Summary
- accumulate resize changes before persisting
- save layout once on mouseup to reduce storage calls

## Testing
- `npm test` (fails: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7d307dc3c83208fb9ab9cd3755aaa