### PR TITLE
feat: improve resize handling

### DIFF
--- a/render.js
+++ b/render.js
@@ -6,9 +6,15 @@ let floatingMenu;
 let selectedGroups = [];
 
 const GRID = 40;
+// Pixels from bottom-right corner that count as resize handle hitbox
+const RESIZE_HITBOX = 24;
 
 const ro = new ResizeObserver((entries) => {
   for (const entry of entries) {
+    if (entry.target.dataset.resizing === '0') {
+      // If an element was resized without the flag, enable it to snap to grid
+      entry.target.dataset.resizing = '1';
+    }
     if (entry.target.dataset.resizing === '1') {
       const baseW = Math.round(entry.contentRect.width / GRID) * GRID;
       const baseH = Math.round(entry.contentRect.height / GRID) * GRID;
@@ -46,7 +52,7 @@ const ro = new ResizeObserver((entries) => {
   }
 });
 
-document.addEventListener('mouseup', () => {
+document.addEventListener('pointerup', () => {
   document.querySelectorAll('.group').forEach((g) => {
     g.dataset.resizing = '0';
     g.style.minWidth = '';
@@ -209,10 +215,11 @@ export function render(state, editing, T, I, handlers, saveFn) {
       if (state.notesBox?.h) noteGrp.style.height = state.notesBox.h + 'px';
       noteGrp.style.resize = editing ? 'both' : 'none';
       if (editing) {
-        noteGrp.addEventListener('mousedown', (e) => {
+        noteGrp.addEventListener('pointerdown', (e) => {
           const rect = noteGrp.getBoundingClientRect();
           const withinHandle =
-            e.clientX >= rect.right - 20 && e.clientY >= rect.bottom - 20;
+            e.clientX >= rect.right - RESIZE_HITBOX &&
+            e.clientY >= rect.bottom - RESIZE_HITBOX;
           if (withinHandle) {
             noteGrp.dataset.resizing = '1';
             noteGrp.style.minWidth = noteGrp.scrollWidth + 'px';
@@ -293,10 +300,11 @@ export function render(state, editing, T, I, handlers, saveFn) {
       }
       grp.style.resize = editing ? 'both' : 'none';
       if (editing) {
-        grp.addEventListener('mousedown', (e) => {
+        grp.addEventListener('pointerdown', (e) => {
           const rect = grp.getBoundingClientRect();
           const withinHandle =
-            e.clientX >= rect.right - 20 && e.clientY >= rect.bottom - 20;
+            e.clientX >= rect.right - RESIZE_HITBOX &&
+            e.clientY >= rect.bottom - RESIZE_HITBOX;
           if (withinHandle) {
             grp.dataset.resizing = '1';
             grp.style.minWidth = grp.scrollWidth + 'px';
@@ -406,10 +414,11 @@ export function render(state, editing, T, I, handlers, saveFn) {
     if (g.resized) grp.style.height = g.h + 'px';
     grp.style.resize = editing ? 'both' : 'none';
     if (editing) {
-      grp.addEventListener('mousedown', (e) => {
+      grp.addEventListener('pointerdown', (e) => {
         const rect = grp.getBoundingClientRect();
         const withinHandle =
-          e.clientX >= rect.right - 20 && e.clientY >= rect.bottom - 20;
+          e.clientX >= rect.right - RESIZE_HITBOX &&
+          e.clientY >= rect.bottom - RESIZE_HITBOX;
         if (withinHandle) {
           grp.dataset.resizing = '1';
           grp.style.minWidth = grp.scrollWidth + 'px';


### PR DESCRIPTION
## Summary
- expand resize hitbox and use pointer events for group handles
- ensure ResizeObserver snaps to grid even if `data-resizing` wasn't set
- reset `data-resizing` on pointer release

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68c7d93e54e4832084e26e8b754acf10