### PR TITLE
Switch layout to CSS grid

### DIFF
--- a/render.js
+++ b/render.js
@@ -10,7 +10,7 @@ const GRID = 40;
 const ro = new ResizeObserver((entries) => {
   for (const entry of entries) {
     if (entry.target.dataset.resizing === '1') {
-      const baseW = Math.round(entry.contentRect.width / GRID) * GRID;
+      // Snap only the height to grid units
       const baseH = Math.round(entry.contentRect.height / GRID) * GRID;
 
       const targets = selectedGroups.includes(entry.target)
@@ -20,7 +20,7 @@ const ro = new ResizeObserver((entries) => {
       targets.forEach((el) => {
         const minW = el.scrollWidth;
         const minH = el.scrollHeight;
-        let w = baseW;
+        let w = entry.contentRect.width;
         let h = baseH;
         if (w < minW) w = minW;
         if (h < minH) h = minH;

--- a/styles.css
+++ b/styles.css
@@ -220,8 +220,9 @@ main {
   flex: 1;
 }
 .grid {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(var(--group-width), 1fr));
+  grid-auto-rows: 40px;
   gap: 16px;
 }
 .group {


### PR DESCRIPTION
## Summary
- replace flex-based grid with CSS Grid
- simplify resize observer to snap only height to 40px units

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7e33063288320959e9174612ddc88