### PR TITLE
Use anchor element for link items

### DIFF
--- a/render.js
+++ b/render.js
@@ -541,11 +541,17 @@ export function render(state, editing, T, I, handlers, saveFn) {
       itemsScroll.appendChild(empty);
     } else {
       filteredItems.forEach((it) => {
-        const card = document.createElement('div');
+        const isLink = !editing && it.type === 'link';
+        const card = document.createElement(isLink ? 'a' : 'div');
         card.className = 'item';
         card.dataset.gid = g.id;
         card.dataset.iid = it.id;
         card.draggable = editing;
+        if (isLink) {
+          card.href = it.url;
+          card.target = '_blank';
+          card.rel = 'noopener';
+        }
         if (editing) {
           card.addEventListener('dragstart', (e) => {
             e.dataTransfer.setData(
@@ -598,10 +604,7 @@ export function render(state, editing, T, I, handlers, saveFn) {
                       : I.puzzle
                 }</div>`;
 
-        const metaHtml =
-          it.type === 'link'
-            ? `<a class="meta" href="${it.url}" target="_blank" rel="noopener"><div class="title">${escapeHtml(it.title || '(be pavadinimo)')}</div><div class="sub">${escapeHtml(it.note || '')}</div></a>`
-            : `<div class="meta"><div class="title">${escapeHtml(it.title || '(be pavadinimo)')}</div><div class="sub">${escapeHtml(it.note || '')}</div></div>`;
+        const metaHtml = `<div class="meta"><div class="title">${escapeHtml(it.title || '(be pavadinimo)')}</div><div class="sub">${escapeHtml(it.note || '')}</div></div>`;
 
         const actionsHtml = editing
           ? `<div class="actions">
@@ -689,8 +692,7 @@ export function render(state, editing, T, I, handlers, saveFn) {
               return;
             }
           } else {
-            if (it.type === 'link') window.open(it.url, '_blank');
-            else previewItem(it, card);
+            if (it.type !== 'link') previewItem(it, card);
           }
         });
 

--- a/styles.css
+++ b/styles.css
@@ -306,6 +306,14 @@ main {
     0.2s ease background,
     0.2s ease transform;
 }
+a.item {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  text-decoration: none;
+  color: inherit;
+  cursor: pointer;
+}
 .item.dragging {
   opacity: 0.45;
 }


### PR DESCRIPTION
## Summary
- render link-type items as `<a>` elements and move icon/text inside
- add styles for `a.item` and open non-link items only in JS

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7fb30f1788320a83a1d35835b9fad