### PR TITLE
Remove min-size assignment from ResizeObserver

### DIFF
--- a/render.js
+++ b/render.js
@@ -39,8 +39,6 @@ const ro = new ResizeObserver((entries) => {
         if (h < minH) h = minH;
         el.style.width = w + 'px';
         el.style.height = h + 'px';
-        el.style.minWidth = minW + 'px';
-        el.style.minHeight = minH + 'px';
         if (el.dataset.id === 'notes') {
           currentState.notesBox = { w, h };
         } else {


### PR DESCRIPTION
## Summary
- Allow ResizeObserver to update width and height only, leaving min size handling to mousedown events.

## Testing
- ❌ `npm test` (no tests specified)
- ✅ `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c800c1baf88320859ef239fd6d87a6