### PR TITLE
Use CSS grid for responsive card layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -220,8 +220,8 @@ main {
   flex: 1;
 }
 .grid {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(var(--group-width), 1fr));
   gap: 16px;
 }
 .group {


### PR DESCRIPTION
## Summary
- switch `.grid` from flexbox to CSS grid with `repeat(auto-fill, minmax(var(--group-width), 1fr))` for better wrapping

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`
- `npx -y playwright@1.49.0 install chromium` (fails: download forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68c8047c35d08320a5ff7496bbf0e9b5