### PR TITLE
Add group size CSS variables and document design settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,21 @@ Statinis vieno failo HTML projektas, skirtas publikuoti per **GitHub Pages**.
 - Pastabų kortelę galima perkelti tarp grupių drag-and-drop būdu.
 - Spalvų meniu turi mygtuką **Atstatyti**, grąžinantį numatytas spalvas.
 
+## Dizaino nustatymai
+
+Grupių kortelių matmenys valdomi CSS kintamaisiais:
+
+| Kintamasis | Reikšmė | Aprašymas |
+|------------|---------|-----------|
+| `--group-width-sm` | `240px` | Mažos grupės plotis |
+| `--group-width-md` | `360px` | Vidutinės grupės plotis (numatytas) |
+| `--group-width-lg` | `480px` | Didelės grupės plotis |
+| `--group-height-sm` | `240px` | Mažos grupės aukštis |
+| `--group-height-md` | `360px` | Vidutinės grupės aukštis |
+| `--group-height-lg` | `480px` | Didelės grupės aukštis |
+
+Šie kintamieji naudojami `.group--sm`, `.group--md` ir `.group--lg` klasėms.
+
 ## Smoke test
 
 Šie žingsniai aktualūs tik atnaujinus ir vėl įjungus Google Sheets sinchronizavimą.

--- a/styles.css
+++ b/styles.css
@@ -14,7 +14,15 @@
   --ok: #8ecae6;
   --card: #0f141a;
   --shadow: 0 6px 20px rgba(0, 0, 0, 0.25);
-  --group-width: 360px;
+  /* numatyti grupių matmenys */
+  --group-width-sm: 240px;
+  --group-width-md: 360px;
+  --group-width-lg: 480px;
+  --group-height-sm: 240px;
+  --group-height-md: 360px;
+  --group-height-lg: 480px;
+  /* numatytasis plotis grid'e */
+  --group-width: var(--group-width-md);
 }
 .theme-light:root {
   --bg: #f6f8fb;
@@ -240,18 +248,18 @@ main {
 }
 
 .group--sm {
-  width: 240px;
-  height: 240px;
+  width: var(--group-width-sm);
+  height: var(--group-height-sm);
 }
 
 .group--md {
-  width: 360px;
-  height: 360px;
+  width: var(--group-width-md);
+  height: var(--group-height-md);
 }
 
 .group--lg {
-  width: 480px;
-  height: 480px;
+  width: var(--group-width-lg);
+  height: var(--group-height-lg);
 }
 
 .group.selected {


### PR DESCRIPTION
## Summary
- define CSS variables for small/medium/large group widths and heights
- use new variables in `.group--sm/md/lg` classes
- document group size variables in README "Dizaino nustatymai" section

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c80aa862888320b3c9f87a20fd4017