### PR TITLE
Store group dimensions and drop size classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,18 +27,9 @@ Statinis vieno failo HTML projektas, skirtas publikuoti per **GitHub Pages**.
 
 ## Dizaino nustatymai
 
-Grupių kortelių matmenys valdomi CSS kintamaisiais:
-
-| Kintamasis | Reikšmė | Aprašymas |
-|------------|---------|-----------|
-| `--group-width-sm` | `240px` | Mažos grupės plotis |
-| `--group-width-md` | `360px` | Vidutinės grupės plotis (numatytas) |
-| `--group-width-lg` | `480px` | Didelės grupės plotis |
-| `--group-height-sm` | `240px` | Mažos grupės aukštis |
-| `--group-height-md` | `360px` | Vidutinės grupės aukštis |
-| `--group-height-lg` | `480px` | Didelės grupės aukštis |
-
-Šie kintamieji naudojami `.group--sm`, `.group--md` ir `.group--lg` klasėms.
+Grupių kortelių matmenys nustatomi per `style` atributus ir saugomi naršyklėje
+(`group.width`, `group.height`, `notesBox.width`, `notesBox.height`).
+Numatyti matmenys – 360×360 px.
 
 ## Smoke test
 

--- a/app.js
+++ b/app.js
@@ -83,7 +83,7 @@ let state = load() || seed();
 if (!('notes' in state)) state.notes = localStorage.getItem('notes') || '';
 if (!('notesOpts' in state)) state.notesOpts = { size: 16, padding: 8 };
 if (!state.notesTitle) state.notesTitle = T.notes;
-if (!('notesBox' in state)) state.notesBox = { size: 'md' };
+if (!('notesBox' in state)) state.notesBox = { width: 360, height: 360 };
 if (!('notesPos' in state)) state.notesPos = 0;
 if (!state.title) state.title = DEFAULT_TITLE;
 let editing = false;
@@ -105,6 +105,19 @@ pageIconEl.addEventListener('input', () => {
 });
 
 const uid = () => Math.random().toString(36).slice(2, 10);
+
+const SIZE_MAP = {
+  sm: { width: 240, height: 240 },
+  md: { width: 360, height: 360 },
+  lg: { width: 480, height: 480 },
+};
+
+function sizeFromDims(w, h) {
+  const max = Math.max(w, h);
+  if (max >= 420) return 'lg';
+  if (max >= 300) return 'md';
+  return 'sm';
+}
 
 function parseIframe(html) {
   const match = html.match(/<iframe[^>]*src="([^"]+)"[^>]*>/i);
@@ -152,7 +165,7 @@ async function addGroup() {
     id: uid(),
     name: res.name,
     color: res.color,
-    size: res.size,
+    ...(SIZE_MAP[res.size] ?? SIZE_MAP.md),
     items: [],
   });
   save(state);
@@ -165,12 +178,12 @@ async function editGroup(gid) {
   const res = await groupFormDialog(T, {
     name: g.name,
     color: g.color,
-    size: g.size,
+    size: sizeFromDims(g.width ?? 360, g.height ?? 360),
   });
   if (!res) return;
   g.name = res.name;
   g.color = res.color;
-  g.size = res.size;
+  Object.assign(g, SIZE_MAP[res.size] ?? SIZE_MAP.md);
   save(state);
   renderAll();
 }
@@ -185,7 +198,7 @@ async function addChart() {
     name: res.title,
     url: parsed.src,
     h: parsed.h ? parsed.h + 56 : undefined,
-    size: 'md',
+    ...SIZE_MAP.md,
   });
   save(state);
   renderAll();

--- a/storage.js
+++ b/storage.js
@@ -4,22 +4,47 @@ export function load() {
   try {
     const data = JSON.parse(localStorage.getItem(STORAGE_KEY) || '');
     if (data && Array.isArray(data.groups)) {
-      data.groups.forEach((g) =>
+      data.groups.forEach((g) => {
         g.items?.forEach((it) => {
           if (!('iconUrl' in it)) it.iconUrl = '';
           if (!('icon' in it)) it.icon = '';
-        }),
-      );
+        });
+        if (typeof g.width !== 'number' || typeof g.height !== 'number') {
+          let width = 360;
+          let height = 360;
+          if (g.size === 'sm') {
+            width = 240;
+            height = 240;
+          } else if (g.size === 'lg') {
+            width = 480;
+            height = 480;
+          }
+          g.width = width;
+          g.height = height;
+        }
+        delete g.size;
+      });
       if (typeof data.notes !== 'string') data.notes = '';
       if (typeof data.notesTitle !== 'string') data.notesTitle = '';
       if (typeof data.title !== 'string') data.title = '';
       if (typeof data.icon !== 'string') data.icon = '';
       if (
         !data.notesBox ||
-        typeof data.notesBox.size !== 'string' ||
-        !['sm', 'md', 'lg'].includes(data.notesBox.size)
-      )
-        data.notesBox = { size: 'md' };
+        typeof data.notesBox.width !== 'number' ||
+        typeof data.notesBox.height !== 'number'
+      ) {
+        const sz = data.notesBox?.size;
+        let width = 360;
+        let height = 360;
+        if (sz === 'sm') {
+          width = 240;
+          height = 240;
+        } else if (sz === 'lg') {
+          width = 480;
+          height = 480;
+        }
+        data.notesBox = { width, height };
+      }
       if (
         !data.notesOpts ||
         typeof data.notesOpts.size !== 'number' ||
@@ -43,7 +68,7 @@ export function seed() {
     groups: [],
     notes: '',
     notesTitle: '',
-    notesBox: { size: 'md' },
+    notesBox: { width: 360, height: 360 },
     notesOpts: { size: 16, padding: 8 },
     notesPos: 0,
     title: '',

--- a/styles.css
+++ b/styles.css
@@ -14,15 +14,6 @@
   --ok: #8ecae6;
   --card: #0f141a;
   --shadow: 0 6px 20px rgba(0, 0, 0, 0.25);
-  /* numatyti grupių matmenys */
-  --group-width-sm: 240px;
-  --group-width-md: 360px;
-  --group-width-lg: 480px;
-  --group-height-sm: 240px;
-  --group-height-md: 360px;
-  --group-height-lg: 480px;
-  /* numatytasis plotis grid'e */
-  --group-width: var(--group-width-md);
 }
 .theme-light:root {
   --bg: #f6f8fb;
@@ -229,7 +220,7 @@ main {
 }
 .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(var(--group-width), 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
   gap: 16px;
 }
 .group {
@@ -245,21 +236,6 @@ main {
   transition:
     0.2s ease background,
     0.2s ease transform;
-}
-
-.group--sm {
-  width: var(--group-width-sm);
-  height: var(--group-height-sm);
-}
-
-.group--md {
-  width: var(--group-width-md);
-  height: var(--group-height-md);
-}
-
-.group--lg {
-  width: var(--group-width-lg);
-  height: var(--group-height-lg);
 }
 
 .group.selected {


### PR DESCRIPTION
## Summary
- switch group sizing from CSS classes to inline `style` width/height and persist values
- convert stored data to use `width`/`height` for groups and notes box
- simplify layout styles by dropping size-related variables and classes

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c81a70cc5083208bd8da7e5020f48c