### PR TITLE
Switch grid layout to flex

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -219,9 +219,10 @@ main {
   flex: 1;
 }
 .grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
+  display: flex;
+  flex-wrap: wrap;
   gap: 16px;
+  align-content: flex-start;
 }
 .group {
   background: var(--panel);
@@ -230,6 +231,7 @@ main {
   box-shadow: var(--shadow);
   display: flex;
   flex-direction: column;
+  flex: 0 0 auto;
   min-height: 100px;
   overflow: auto;
   resize: both;


### PR DESCRIPTION
## Summary
- replace CSS grid with flexbox for card container
- ensure group cards don't shrink by default

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c82521172c8320949d6878b783345f