### PR TITLE
Add extra link icons and notes removal

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,6 +37,7 @@ const T = {
   editMode: 'Redaguoti',
   done: 'Baigti',
   deleteGroup: 'Pašalinti grupę',
+  deleteNotes: 'Pašalinti pastabų kortelę',
   empty: 'Nėra įrašų. Spauskite ＋, kad pridėtumėte nuorodą ar įterpimą.',
   noMatches: 'Nėra atitikmenų šioje grupėje.',
   itemType: 'Įrašo tipas',
@@ -52,6 +53,7 @@ const T = {
   confirmDelGroup: 'Pašalinti šią grupę ir visus jos įrašus?',
   confirmDelChart: 'Pašalinti šį grafiką?',
   confirmDelItem: 'Pašalinti šį įrašą?',
+  confirmDelNotes: 'Pašalinti pastabų kortelę?',
   invalidImport: 'Netinkamas failo formatas',
   save: 'Išsaugoti',
   cancel: 'Atšaukti',
@@ -130,6 +132,7 @@ function renderAll() {
       editItem,
       editChart,
       editNotes,
+      removeNotes,
       toggleCollapse,
       confirmDialog: (msg) => confirmDlg(T, msg),
     },
@@ -215,6 +218,16 @@ async function editNotes() {
   state.notesTitle = res.title || T.notes;
   state.notes = res.text;
   state.notesOpts = { size: res.size, padding: res.padding };
+  save(state);
+  renderAll();
+}
+
+// Ištrina pastabų kortelę, bet palieka paskutines parinktis ateičiai
+async function removeNotes() {
+  const ok = await confirmDlg(T, T.confirmDelNotes);
+  if (!ok) return;
+  state.notes = '';
+  state.notesTitle = T.notes;
   save(state);
   renderAll();
 }

--- a/forms.js
+++ b/forms.js
@@ -83,6 +83,12 @@ export function itemFormDialog(T, data = {}) {
       'calendar',
       'clock',
       'user',
+      'clipboard',
+      'chat',
+      'video',
+      'map',
+      'shield',
+      'alert',
     ];
     const iconButtons = iconKeys
       .map(

--- a/icons.js
+++ b/icons.js
@@ -43,4 +43,16 @@ export const I = {
     '<svg class="icon" viewBox="0 0 24 24"><circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="M4.93 4.93l1.41 1.41"/><path d="M17.66 17.66l1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="M6.34 17.66l-1.41 1.41"/><path d="M19.07 4.93l-1.41 1.41"/></svg>',
   moon:
     '<svg class="icon" viewBox="0 0 24 24"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg>',
+  alert:
+    '<svg class="icon" viewBox="0 0 24 24"><path d="M10.29 3.86 1.82 18.57A2 2 0 0 0 3.53 21h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><path d="M12 9v4"/><path d="M12 17h.01"/></svg>',
+  chat:
+    '<svg class="icon" viewBox="0 0 24 24"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.5 8.5 0 0 1 8 8z"/></svg>',
+  clipboard:
+    '<svg class="icon" viewBox="0 0 24 24"><rect x="8" y="2" width="8" height="4" rx="1"/><path d="M16 4h1a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h1"/><path d="M9 13h6"/><path d="M9 17h4"/></svg>',
+  map:
+    '<svg class="icon" viewBox="0 0 24 24"><path d="M9 3 15 1v16l-6 2-6-2V5l6-2Z"/><path d="M9 3v16"/><path d="M15 1v16"/><path d="M21 3v16l-6-2"/></svg>',
+  shield:
+    '<svg class="icon" viewBox="0 0 24 24"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>',
+  video:
+    '<svg class="icon" viewBox="0 0 24 24"><rect x="1" y="5" width="15" height="14" rx="2"/><path d="m23 7-7 5 7 5V7z"/></svg>',
 };

--- a/render.js
+++ b/render.js
@@ -287,6 +287,7 @@ export function render(state, editing, T, I, handlers, saveFn) {
           editing
             ? `<div class="group-actions">
           <button type="button" title="${T.edit}" aria-label="${T.edit}" data-act="edit">${I.pencil}</button>
+          <button type="button" class="btn-danger" title="${T.deleteNotes}" aria-label="${T.deleteNotes}" data-act="del">${I.trash}</button>
         </div>`
             : ''
         }`;
@@ -294,6 +295,7 @@ export function render(state, editing, T, I, handlers, saveFn) {
         const btn = e.target.closest('button');
         if (!btn) return;
         if (btn.dataset.act === 'edit') handlers.editNotes();
+        if (btn.dataset.act === 'del') handlers.removeNotes();
       });
       noteGrp.appendChild(h);
       const itemsWrap = document.createElement('div');


### PR DESCRIPTION
## Summary
- add six extra SVG icons and expose them in the link icon picker
- allow the notes card to be deleted with a confirmation while keeping layout options

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c82dbd40c48320bd9beef4bc69e4ad