### PR TITLE
Use crypto.randomUUID for uid generation

### DIFF
--- a/app.js
+++ b/app.js
@@ -110,7 +110,7 @@ pageIconEl.addEventListener('input', () => {
   save(state);
 });
 
-const uid = () => Math.random().toString(36).slice(2, 10);
+const uid = () => crypto.randomUUID().slice(0, 8);
 
 function parseIframe(html) {
   const match = html.match(/<iframe[^>]*src="([^"]+)"[^>]*>/i);


### PR DESCRIPTION
## Summary
- replace Math.random-based uid generation with `crypto.randomUUID()` slicing for improved uniqueness

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c84986c4508320a571425721012656