### PR TITLE
Improve theme initialization defaults

### DIFF
--- a/app.js
+++ b/app.js
@@ -294,10 +294,21 @@ function importJson(file) {
 }
 
 function applyTheme() {
-  const light = localStorage.getItem('ed_dash_theme') === 'light';
+  let theme = localStorage.getItem('ed_dash_theme');
+  if (!theme) {
+    const prefersLight =
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-color-scheme: light)').matches;
+    // Pakeiskite numatytą temą, jei skyriui reikia kitokio starto varianto.
+    theme = prefersLight ? 'light' : 'dark';
+    localStorage.setItem('ed_dash_theme', theme);
+  }
+  const light = theme === 'light';
   document.documentElement.classList.toggle('theme-light', light);
-  themeBtn.innerHTML = `${light ? I.sun : I.moon} <span>${T.theme}</span>`;
-  themeBtn.setAttribute('aria-label', light ? T.toDark : T.toLight);
+  const label = light ? T.toDark : T.toLight;
+  const icon = light ? I.moon : I.sun;
+  themeBtn.innerHTML = `${icon} <span>${label}</span>`;
+  themeBtn.setAttribute('aria-label', label);
 }
 
 function toggleTheme() {

--- a/render.js
+++ b/render.js
@@ -773,7 +773,15 @@ export function updateEditingUI(editing, T, I, renderFn) {
 }
 
 export function applyTheme() {
-  const theme = localStorage.getItem('ed_dash_theme') || 'dark';
+  let theme = localStorage.getItem('ed_dash_theme');
+  if (!theme) {
+    const prefersLight =
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-color-scheme: light)').matches;
+    // Jei reikia kitos pradinės temos – keiskite šiame bloke.
+    theme = prefersLight ? 'light' : 'dark';
+    localStorage.setItem('ed_dash_theme', theme);
+  }
   if (theme === 'light') document.documentElement.classList.add('theme-light');
   else document.documentElement.classList.remove('theme-light');
 }


### PR DESCRIPTION
## Summary
- default the dashboard theme using the user's preferred color scheme when no saved choice exists
- update the theme toggle button icon/text to describe the next action and persist the initial decision
- align the shared render helper with the new theme initialisation logic

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c863c4495883209c61696aa8ca1c80