### PR TITLE
Add node tests for size helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,14 +4,14 @@
   "description": "Statinis vieno failo HTML projektas, skirtas publikuoti per **GitHub Pages**.",
   "main": "app.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test tests",
     "lint": "eslint .",
     "format": "prettier --write ."
   },
   "keywords": [],
   "author": "",
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "devDependencies": {
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^10.1.8",

--- a/tests/sizes.test.js
+++ b/tests/sizes.test.js
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { sizeFromWidth, sizeFromHeight } from '../sizes.js';
+
+test('sizeFromWidth klasifikacijos', () => {
+  assert.strictEqual(sizeFromWidth(240), 'sm');
+  assert.strictEqual(sizeFromWidth(299), 'sm');
+  assert.strictEqual(sizeFromWidth(300), 'md');
+  assert.strictEqual(sizeFromWidth(419), 'md');
+  assert.strictEqual(sizeFromWidth(420), 'lg');
+  assert.strictEqual(sizeFromWidth(600), 'lg');
+});
+
+test('sizeFromHeight klasifikacijos', () => {
+  assert.strictEqual(sizeFromHeight(240), 'sm');
+  assert.strictEqual(sizeFromHeight(299), 'sm');
+  assert.strictEqual(sizeFromHeight(300), 'md');
+  assert.strictEqual(sizeFromHeight(419), 'md');
+  assert.strictEqual(sizeFromHeight(420), 'lg');
+  assert.strictEqual(sizeFromHeight(600), 'lg');
+});


### PR DESCRIPTION
## Summary
- add node:test coverage verifying the sizeFromWidth and sizeFromHeight thresholds
- configure the npm test script to run the new suite and treat the project as an ES module package

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c865305a5c832082e37441b9f12e31