### PR TITLE
Add timestamped export filename and tests

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,6 +10,7 @@ import {
 } from './forms.js';
 import { I } from './icons.js';
 import { Tlt } from './i18n.js';
+import { exportJson } from './exporter.js';
 
 const T = Tlt;
 // Hook future English localisation: fill T.en when translations are ready.
@@ -265,17 +266,6 @@ async function editItem(gid, iid) {
   renderAll();
 }
 
-function exportJson() {
-  const blob = new Blob([JSON.stringify(state, null, 2)], {
-    type: 'application/json',
-  });
-  const a = document.createElement('a');
-  a.href = URL.createObjectURL(blob);
-  a.download = 'smp-skydas.json';
-  a.click();
-  URL.revokeObjectURL(a.href);
-}
-
 function importJson(file) {
   const reader = new FileReader();
   reader.onload = () => {
@@ -355,7 +345,7 @@ document.getElementById('addNote').addEventListener('click', () => {
   editNotes();
 });
 document.getElementById('exportBtn').addEventListener('click', () => {
-  exportJson();
+  exportJson(state);
 });
 document.getElementById('importBtn').addEventListener('click', () => {
   document.getElementById('fileInput').click();

--- a/exporter.js
+++ b/exporter.js
@@ -1,0 +1,27 @@
+/**
+ * Eksportuoja prietaisų skydelio būseną į JSON failą ir inicijuoja parsisiuntimą.
+ * @param {object} state - Dabartinė būsena, kuri bus serializuojama.
+ * @param {object} [deps] - Priklausomybės testavimui (document, URL, now).
+ * @returns {HTMLAnchorElement} Nuoroda, kuri naudojama parsisiuntimui (patogu testams).
+ */
+export function exportJson(state, deps = {}) {
+  const {
+    document: doc = globalThis.document,
+    URL: urlObj = globalThis.URL,
+    now = () => Date.now(),
+  } = deps;
+  if (!doc || !urlObj) {
+    throw new Error('Reikalingi document ir URL objektai eksportui.');
+  }
+  const blob = new Blob([JSON.stringify(state, null, 2)], {
+    type: 'application/json',
+  });
+  const a = doc.createElement('a');
+  a.href = urlObj.createObjectURL(blob);
+  const title = state?.title || 'smp-skydas';
+  const timestamp = typeof now === 'function' ? now() : Date.now();
+  a.download = `${title}-${timestamp}.json`;
+  if (typeof a.click === 'function') a.click();
+  urlObj.revokeObjectURL(a.href);
+  return a;
+}

--- a/tests/exportJson.test.js
+++ b/tests/exportJson.test.js
@@ -1,0 +1,73 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { exportJson } from '../exporter.js';
+
+test('exportJson naudoja būsenos pavadinimą faile', () => {
+  const fakeNow = 1700000000000;
+  const state = { title: 'pagalba', groups: [] };
+  let anchor;
+  let createdBlob;
+  const doc = {
+    createElement(tag) {
+      assert.equal(tag, 'a');
+      anchor = {
+        click() {
+          anchor.clicked = true;
+        },
+      };
+      return anchor;
+    },
+  };
+  const urlObj = {
+    createObjectURL(blob) {
+      createdBlob = blob;
+      return 'blob:fake';
+    },
+    revokeObjectURL(href) {
+      this.revokedHref = href;
+    },
+  };
+
+  const result = exportJson(state, {
+    document: doc,
+    URL: urlObj,
+    now: () => fakeNow,
+  });
+
+  assert.equal(result, anchor);
+  assert.ok(createdBlob instanceof Blob, 'turi būti sukurtas Blob');
+  assert.equal(result.download, `pagalba-${fakeNow}.json`);
+  assert.equal(anchor.clicked, true, 'turi būti iškviestas click()');
+  assert.equal(urlObj.revokedHref, 'blob:fake');
+});
+
+test('exportJson naudoja numatytą pavadinimą, jei nėra antraštės', () => {
+  const fakeNow = 1700000000999;
+  const state = { groups: [] };
+  let anchor;
+  const doc = {
+    createElement() {
+      anchor = {
+        click() {
+          anchor.clicked = true;
+        },
+      };
+      return anchor;
+    },
+  };
+  const urlObj = {
+    createObjectURL() {
+      return 'blob:fallback';
+    },
+    revokeObjectURL() {},
+  };
+
+  const result = exportJson(state, {
+    document: doc,
+    URL: urlObj,
+    now: () => fakeNow,
+  });
+
+  assert.equal(result.download, `smp-skydas-${fakeNow}.json`);
+  assert.equal(anchor.clicked, true);
+});


### PR DESCRIPTION
## Summary
- extract JSON eksportavimo logiką į atskirą modulį, kad būtų galima injekuoti priklausomybes
- nustatyti parsisiunčiamo failo pavadinimą pagal skydelio antraštę ir įtraukti laiko žymą
- pridėti vienetinius testus, kurie tikrina pavadinimo generavimą bei Blob kūrimą

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c86666b8748320a2a112f0837fac63