### PR TITLE
Display reminder indicator for scheduled reminders

### DIFF
--- a/render.js
+++ b/render.js
@@ -643,7 +643,18 @@ export function render(state, editing, T, I, handlers, saveFn) {
                       : I.puzzle
                 }</div>`;
 
-        const metaHtml = `<div class="meta"><div class="title">${escapeHtml(it.title || '(be pavadinimo)')}</div><div class="sub">${escapeHtml(it.note || '')}</div></div>`;
+        const hasReminder = Number.isFinite(it.reminderAt);
+        const reminderLabel = escapeHtml(
+          T.reminderNotificationTitle || 'Priminimas',
+        );
+        const reminderHtml = hasReminder
+          ? `<span class="reminder-flag" role="img" aria-label="${reminderLabel}" title="${reminderLabel}">⏰</span>`
+          : '';
+        const metaHtml = `<div class="meta"><div class="title-row"><div class="title">${escapeHtml(
+          it.title || '(be pavadinimo)',
+        )}</div>${reminderHtml}</div><div class="sub">${escapeHtml(
+          it.note || '',
+        )}</div></div>`;
 
         const actionsHtml = editing
           ? `<div class="actions">

--- a/styles.css
+++ b/styles.css
@@ -351,6 +351,12 @@ a.item {
   color: inherit;
   display: block;
 }
+.item .title-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
 .item .meta .title {
   font-weight: 700;
   font-size: 1rem; /* keep size consistent after leaving edit mode */
@@ -358,6 +364,8 @@ a.item {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  flex: 1;
+  min-width: 0;
 }
 .item .meta .sub {
   font-size: 0.875rem; /* match default input size */
@@ -365,6 +373,13 @@ a.item {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+.reminder-flag {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.875rem;
+  line-height: 1;
+  color: var(--warn);
 }
 .item .actions {
   margin-left: auto;


### PR DESCRIPTION
## Summary
- show a reminder flag next to item titles whenever a reminder is scheduled
- expose the reminder flag with accessible labelling and add styling for the icon

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9043125c083208c988f7b6e441def