### PR TITLE
Add reminder snooze and edit actions

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -24,6 +24,8 @@ export const Tlt = {
   reminderItemBody: 'Patikrinkite įrašą',
   reminders: 'Priminimai',
   noReminders: 'Priminimų nėra',
+  reminderSnooze: 'Atidėti 5 min.',
+  reminderEdit: 'Keisti laiką',
   toDark: 'Perjungti į tamsią temą',
   toLight: 'Perjungti į šviesią temą',
   openAll: 'Atverti visas',


### PR DESCRIPTION
## Summary
- add snooze and edit buttons to the reminders dialog and wire them to new actions
- extend reminder management to handle snoozing and editing with state persistence and sync updates
- localize new reminder labels for Lithuanian UI text

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c91ae2b2a08320be31851c3fe762c0