### PR TITLE
Add reminder badge count to reminders button

### DIFF
--- a/app.js
+++ b/app.js
@@ -326,9 +326,39 @@ async function openReminders() {
   });
 }
 
+/**
+ * Updates the reminders button badge with the current count.
+ * @param {number} count Total reminder entries detected.
+ */
+function updateReminderBadge(count) {
+  if (!remindersBtn) return;
+
+  const safeCount = Number.isFinite(count) && count > 0 ? Math.round(count) : 0;
+  const label = safeCount > 0 ? `${T.reminders} (${safeCount})` : T.reminders;
+  remindersBtn.setAttribute('aria-label', label);
+  remindersBtn.title = label;
+
+  let badge = remindersBtn.querySelector('.reminder-badge');
+  if (safeCount > 0) {
+    if (!badge) {
+      badge = document.createElement('span');
+      badge.className = 'reminder-badge';
+      badge.setAttribute('aria-hidden', 'true');
+      remindersBtn.appendChild(badge);
+    }
+    const displayCount = safeCount > 99 ? '99+' : String(safeCount);
+    badge.textContent = displayCount;
+  } else if (badge) {
+    badge.remove();
+  }
+}
+
 function syncReminders() {
-  if (!reminders) return;
-  reminders.sync(buildReminderEntries());
+  const entries = buildReminderEntries();
+  if (reminders) {
+    reminders.sync(entries);
+  }
+  updateReminderBadge(entries.length);
 }
 
 function persistState() {
@@ -669,10 +699,10 @@ document.getElementById('fileInput').addEventListener('change', (e) => {
 });
 
 reminders = createReminderManager();
-syncReminders();
 remindersBtn.innerHTML = `${I.clock} <span>${T.reminders}</span>`;
-remindersBtn.setAttribute('aria-label', T.reminders);
 remindersBtn.addEventListener('click', openReminders);
+updateReminderBadge(0);
+syncReminders();
 themeBtn.addEventListener('click', toggleTheme);
 editBtn.addEventListener('click', () => {
   editing = !editing;

--- a/styles.css
+++ b/styles.css
@@ -218,6 +218,30 @@ button:hover,
 .btn .icon {
   margin-right: 4px;
 }
+
+#remindersBtn {
+  position: relative;
+}
+
+.reminder-badge {
+  position: absolute;
+  top: 10px;
+  left: 26px;
+  transform: translate(-50%, -50%);
+  background: var(--danger);
+  color: var(--btn-danger-text);
+  border-radius: 999px;
+  min-width: 18px;
+  padding: 2px 6px;
+  font-size: 11px;
+  line-height: 1;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 0 0 2px var(--panel);
+  pointer-events: none;
+}
 .search {
   position: relative;
 }


### PR DESCRIPTION
## Summary
- add a helper to render a reminders count badge on the reminders button and keep the aria label updated
- refresh reminder syncing logic to reuse entries and feed the badge count
- style the badge as a red circle positioned above the clock icon

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c91f62174083209820f8ebfccb947d