### PR TITLE
Support multiple note cards with custom colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Statinis vieno failo HTML projektas, skirtas publikuoti per **GitHub Pages**.
 - Jei pavadinimas tuščias redagavimo režime, rodomas pilkas užrašas „Įveskite pavadinimą“.
 - Spalvų temą galima keisti paspaudus **Tema** – parinktys išsaugomos `localStorage`.
 - Pastabų kortelę galima perkelti tarp grupių drag-and-drop būdu.
+- Galima kurti kelias pastabų korteles, kiekvienai parenkant taškelio spalvą, šrifto dydį ir paraštes.
 - Spalvų meniu turi mygtuką **Atstatyti**, grąžinantį numatytas spalvas.
 - Galima nustatyti priminimus kortelėms ir pastabų blokui (reikalingas naršyklės pranešimų leidimas).
 - Priminimų skydelis leidžia peržiūrėti ir atšaukti aktyvius priminimus.
@@ -40,6 +41,8 @@ Statinis vieno failo HTML projektas, skirtas publikuoti per **GitHub Pages**.
 Grupių kortelių matmenys nustatomi per `style` atributus ir saugomi naršyklėje
 (`group.width`, `group.height`, `notesBox.width`, `notesBox.height`).
 Numatyti matmenys – 360×360 px.
+
+Pastabų kortelės pagal nutylėjimą naudoja 20 px šriftą ir 20 px paraštes.
 
 ## Smoke test
 

--- a/forms.js
+++ b/forms.js
@@ -444,8 +444,9 @@ export function notesDialog(
   data = {
     title: '',
     text: '',
-    size: 16,
-    padding: 8,
+    size: 20,
+    padding: 20,
+    color: '#fef08a',
     reminderMinutes: 0,
     reminderAt: null,
   },
@@ -458,6 +459,7 @@ export function notesDialog(
       <label>${T.notes}<br><textarea name="note" rows="8"></textarea></label>
       <label>${T.noteSize}<br><input name="size" type="number" min="10" max="48"></label>
       <label>${T.notePadding}<br><input name="padding" type="number" min="0" max="100"></label>
+      <label>${T.noteColor}<br><input name="color" type="color"></label>
       <label>${T.reminderMode}<br>
         <select name="reminderMode">
           <option value="${REMINDER_NONE}">${T.reminderNone}</option>
@@ -488,8 +490,9 @@ export function notesDialog(
     const cancel = form.querySelector('[data-act="cancel"]');
     form.title.value = data.title || '';
     form.note.value = data.text || '';
-    form.size.value = data.size || 16;
-    form.padding.value = data.padding || 8;
+    form.size.value = data.size || 20;
+    form.padding.value = data.padding || 20;
+    form.color.value = data.color || '#fef08a';
     const hasReminderMinutes =
       typeof data.reminderMinutes === 'number' && data.reminderMinutes > 0;
     const hasReminderAt = Number.isFinite(data.reminderAt);
@@ -528,8 +531,9 @@ export function notesDialog(
       resolve({
         title: form.title.value.trim(),
         text: form.note.value.trim(),
-        size: parseInt(form.size.value, 10) || 16,
-        padding: parseInt(form.padding.value, 10) || 8,
+        size: parseInt(form.size.value, 10) || 20,
+        padding: parseInt(form.padding.value, 10) || 20,
+        color: form.color.value || '#fef08a',
         reminderMinutes,
         reminderMode,
         reminderAt,

--- a/i18n.js
+++ b/i18n.js
@@ -15,6 +15,7 @@ export const Tlt = {
   noteTitle: 'Pastabų pavadinimas',
   noteSize: 'Šrifto dydis (px)',
   notePadding: 'Paraštės (px)',
+  noteColor: 'Taškelio spalva',
   reminderMinutes: 'Priminimas po (min)',
   reminderMode: 'Priminimo tipas',
   reminderNone: 'Be priminimo',

--- a/reminders.js
+++ b/reminders.js
@@ -32,8 +32,20 @@ function activateEntry(entry, attempt = 0) {
   if (typeof document === 'undefined') return;
   if (attempt > 5) return;
   const data = entry.data;
-  if (data.type === 'notes') {
-    const notesEl = document.querySelector('.group[data-id="notes"]');
+  if (data.type === 'note') {
+    const noteId = String(data.id || '');
+    let notesEl = null;
+    if (noteId && typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
+      notesEl = document.querySelector(`.group[data-id="${CSS.escape(noteId)}"]`);
+    }
+    if (!notesEl && noteId) {
+      notesEl = Array.from(document.querySelectorAll('.group')).find(
+        (el) => el.dataset.id === noteId,
+      );
+    }
+    if (!notesEl) {
+      notesEl = document.querySelector('.group.note-card');
+    }
     if (notesEl) highlightElement(notesEl);
     return;
   }

--- a/tests/notes-migration.test.js
+++ b/tests/notes-migration.test.js
@@ -1,0 +1,50 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { load } from '../storage.js';
+
+const STORAGE_KEY = 'ed_dashboard_lt_v1';
+
+test('legacy notes duomenys migruojami į note tipo kortelę', () => {
+  const reminderAt = Date.now() + 60000;
+  const legacyState = {
+    groups: [],
+    notes: 'Svarbu patikrinti atsargas',
+    notesTitle: 'Prioritetai',
+    notesOpts: { size: 18, padding: 12 },
+    notesBox: { width: 400, height: 260, wSize: 'md', hSize: 'md' },
+    notesReminderMinutes: 5,
+    notesReminderAt: reminderAt,
+    notesPos: 0,
+    title: 'Skydelis',
+  };
+
+  const fakeStorage = {
+    getItem(key) {
+      assert.equal(key, STORAGE_KEY);
+      return JSON.stringify(legacyState);
+    },
+  };
+
+  const originalStorage = globalThis.localStorage;
+  globalThis.localStorage = fakeStorage;
+
+  const state = load();
+
+  assert.ok(Array.isArray(state.groups), 'grupės turi būti masyvas');
+  assert.equal(state.groups.length, 1, 'turi būti viena pastabų kortelė');
+  const note = state.groups[0];
+  assert.equal(note.type, 'note');
+  assert.equal(note.text, legacyState.notes);
+  assert.equal(note.title, legacyState.notesTitle);
+  assert.equal(note.name, legacyState.notesTitle);
+  assert.equal(note.fontSize, 18);
+  assert.equal(note.padding, 12);
+  assert.equal(note.color, '#fef08a');
+  assert.equal(note.width, 400);
+  assert.equal(note.height, 260);
+  assert.equal(note.reminderMinutes, 5);
+  assert.ok(Number.isFinite(note.reminderAt));
+  assert.ok(!('notes' in state));
+
+  globalThis.localStorage = originalStorage;
+});


### PR DESCRIPTION
## Summary
- migrate legacy single-note data into note-type groups and persist multiple note cards with reminders
- render editable note cards with individual accent colors, font/padding defaults, and drag-drop support
- extend the note dialog with color selection, update reminders/listeners, and document/test the new behaviour

## Testing
- npm test
- npm run lint && echo "lint ok"

------
https://chatgpt.com/codex/tasks/task_e_68c93b948c948320a550789b535d306b