### PR TITLE
Remove reminders header button and simplify theme toggle

### DIFF
--- a/app.js
+++ b/app.js
@@ -991,8 +991,9 @@ function applyTheme() {
   document.documentElement.classList.toggle('theme-light', light);
   const label = light ? T.toDark : T.toLight;
   const icon = light ? I.moon : I.sun;
-  themeBtn.innerHTML = `${icon} <span>${label}</span>`;
+  themeBtn.innerHTML = `${icon}`;
   themeBtn.setAttribute('aria-label', label);
+  themeBtn.title = label;
 }
 
 function toggleTheme() {
@@ -1058,8 +1059,10 @@ document.getElementById('fileInput').addEventListener('change', (e) => {
 });
 
 reminders = createReminderManager();
-remindersBtn.innerHTML = `${I.clock} <span>${T.reminders}</span>`;
-remindersBtn.addEventListener('click', openReminders);
+if (remindersBtn) {
+  remindersBtn.innerHTML = `${I.clock} <span>${T.reminders}</span>`;
+  remindersBtn.addEventListener('click', openReminders);
+}
 updateReminderBadge(0);
 syncReminders();
 themeBtn.addEventListener('click', toggleTheme);

--- a/index.html
+++ b/index.html
@@ -76,17 +76,15 @@
             <line x1="12" y1="3" x2="12" y2="15" /></svg
           ><span>Eksportuoti</span>
         </button>
-        <button id="remindersBtn" class="btn" type="button">
+        <button
+          id="themeBtn"
+          class="btn"
+          type="button"
+          aria-label="Perjungti temą"
+        >
           <svg class="icon" viewBox="0 0 24 24">
-            <circle cx="12" cy="12" r="10" />
-            <polyline points="12 6 12 12 16 14" />
+            <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" />
           </svg>
-          <span>Priminimai</span>
-        </button>
-        <button id="themeBtn" class="btn" type="button">
-          <svg class="icon" viewBox="0 0 24 24">
-            <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" /></svg
-          ><span>Tema</span>
         </button>
         <span id="syncStatus" role="status" aria-live="polite"></span>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -219,28 +219,8 @@ button:hover,
   margin-right: 4px;
 }
 
-#remindersBtn {
-  position: relative;
-}
-
-.reminder-badge {
-  position: absolute;
-  top: 10px;
-  left: 26px;
-  transform: translate(-50%, -50%);
-  background: var(--danger);
-  color: var(--btn-danger-text);
-  border-radius: 999px;
-  min-width: 18px;
-  padding: 2px 6px;
-  font-size: 11px;
-  line-height: 1;
-  font-weight: 700;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  box-shadow: 0 0 0 2px var(--panel);
-  pointer-events: none;
+.btn .icon:last-child {
+  margin-right: 0;
 }
 .search {
   position: relative;


### PR DESCRIPTION
## Summary
- remove the reminders shortcut from the header and keep the theme toggle in place
- update the theme toggle logic so the button renders only an icon while retaining accessibility labels
- clean up reminder badge styling that is no longer needed and guard reminder button setup in JS

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c94ce7e8c0832081ae755a2fa3d857