### PR TITLE
Adjust cards to auto-size without scrollbars

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -259,8 +259,8 @@ main {
   display: flex;
   flex-direction: column;
   flex: 0 0 auto;
-  min-height: 100px;
-  overflow: auto;
+  min-height: max-content;
+  overflow: visible;
   resize: both;
   transition:
     0.2s ease background,
@@ -317,7 +317,7 @@ main {
   grid-template-columns: 1fr;
   gap: 6px;
   padding: 8px;
-  overflow: auto;
+  overflow: visible;
 }
 .reminder-highlight {
   outline: 3px solid var(--accent);
@@ -582,8 +582,8 @@ a.item {
   padding: 0;
   display: grid;
   gap: 8px;
-  max-height: 220px;
-  overflow-y: auto;
+  max-height: none;
+  overflow: visible;
 }
 
 .reminder-items li {
@@ -684,8 +684,8 @@ a.item {
   padding: 0;
   display: grid;
   gap: 8px;
-  max-height: 60vh;
-  overflow-y: auto;
+  max-height: none;
+  overflow: visible;
 }
 
 .reminders-list li {


### PR DESCRIPTION
## Summary
- ensure cards use intrinsic sizing so their minimum height follows the content and they no longer render internal scrollbars
- allow list containers inside reminder cards to expand with their contents instead of forcing scroll areas

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c94e7d81f08320a4024db67913f565