### PR TITLE
Remove reminders from note cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Statinis vieno failo HTML projektas, skirtas publikuoti per **GitHub Pages**.
 - Pastabų kortelę galima perkelti tarp grupių drag-and-drop būdu.
 - Galima kurti kelias pastabų korteles, kiekvienai parenkant taškelio spalvą, šrifto dydį ir paraštes.
 - Spalvų meniu turi mygtuką **Atstatyti**, grąžinantį numatytas spalvas.
-- Galima nustatyti priminimus kortelėms ir pastabų blokui (reikalingas naršyklės pranešimų leidimas).
+- Galima nustatyti priminimus įrašams ir per priminimų kortelę (reikalingas naršyklės pranešimų leidimas).
 - Priminimų skydelis leidžia peržiūrėti ir atšaukti aktyvius priminimus.
 - Redagavimo režime galima pridėti priminimų kortelę su vizualiais laikmačiais,
   greitais +5/+10/+15/+30 min. mygtukais ir individualių priminimų sąrašu.

--- a/forms.js
+++ b/forms.js
@@ -447,8 +447,6 @@ export function notesDialog(
     size: 20,
     padding: 20,
     color: '#fef08a',
-    reminderMinutes: 0,
-    reminderAt: null,
   },
 ) {
   return new Promise((resolve) => {
@@ -460,24 +458,6 @@ export function notesDialog(
       <label>${T.noteSize}<br><input name="size" type="number" min="10" max="48"></label>
       <label>${T.notePadding}<br><input name="padding" type="number" min="0" max="100"></label>
       <label>${T.noteColor}<br><input name="color" type="color"></label>
-      <label>${T.reminderMode}<br>
-        <select name="reminderMode">
-          <option value="${REMINDER_NONE}">${T.reminderNone}</option>
-          <option value="${REMINDER_DATETIME}">${T.reminderExactTime}</option>
-          <option value="${REMINDER_MINUTES}">${T.reminderAfter}</option>
-        </select>
-      </label>
-      <label data-reminder="${REMINDER_DATETIME}" hidden>${T.reminderExactTime}<br><input name="reminderAt" type="datetime-local"></label>
-      <label data-reminder="${REMINDER_MINUTES}" hidden>
-        ${T.reminderMinutes}<br>
-        <input name="reminderMinutes" type="number" min="0" step="1">
-        <div class="reminder-quick-buttons" data-reminder-quick>
-          <button type="button" data-minutes="5">${T.reminderPlus5}</button>
-          <button type="button" data-minutes="10">${T.reminderPlus10}</button>
-          <button type="button" data-minutes="15">${T.reminderPlus15}</button>
-          <button type="button" data-minutes="30">${T.reminderPlus30}</button>
-        </div>
-      </label>
       <menu>
         <button type="button" data-act="cancel">${T.cancel}</button>
         <button type="submit" class="btn-accent">${T.save}</button>
@@ -493,19 +473,6 @@ export function notesDialog(
     form.size.value = data.size || 20;
     form.padding.value = data.padding || 20;
     form.color.value = data.color || '#fef08a';
-    const hasReminderMinutes =
-      typeof data.reminderMinutes === 'number' && data.reminderMinutes > 0;
-    const hasReminderAt = Number.isFinite(data.reminderAt);
-    let reminderMode = REMINDER_NONE;
-    if (hasReminderAt) reminderMode = REMINDER_DATETIME;
-    else if (hasReminderMinutes) reminderMode = REMINDER_MINUTES;
-    form.reminderMode.value = reminderMode;
-    form.reminderMinutes.value = hasReminderMinutes ? data.reminderMinutes : '';
-    form.reminderAt.value = hasReminderAt
-      ? formatDateTimeLocal(data.reminderAt)
-      : '';
-    setupReminderControls(form);
-    setupReminderQuickButtons(form);
 
     function cleanup() {
       form.removeEventListener('submit', submit);
@@ -516,27 +483,12 @@ export function notesDialog(
 
     function submit(e) {
       e.preventDefault();
-      const reminderMode = form.reminderMode.value || REMINDER_NONE;
-      const reminderVal = parseInt(form.reminderMinutes.value, 10);
-      const reminderMinutes =
-        reminderMode === REMINDER_MINUTES &&
-        Number.isFinite(reminderVal) &&
-        reminderVal > 0
-          ? Math.max(0, Math.round(reminderVal))
-          : 0;
-      const reminderAt =
-        reminderMode === REMINDER_DATETIME && form.reminderAt.value
-          ? form.reminderAt.value
-          : '';
       resolve({
         title: form.title.value.trim(),
         text: form.note.value.trim(),
         size: parseInt(form.size.value, 10) || 20,
         padding: parseInt(form.padding.value, 10) || 20,
         color: form.color.value || '#fef08a',
-        reminderMinutes,
-        reminderMode,
-        reminderAt,
       });
       cleanup();
     }

--- a/storage.js
+++ b/storage.js
@@ -44,15 +44,9 @@ export function load() {
       const legacyTitle = typeof data.notesTitle === 'string' ? data.notesTitle : '';
       const legacyOpts = data.notesOpts || {};
       const legacyBox = data.notesBox || {};
-      const legacyReminderMinutes = Number.isFinite(data.notesReminderMinutes)
-        ? Math.max(0, Math.round(data.notesReminderMinutes))
-        : 0;
-      const legacyReminderAt = sanitizeTimestamp(data.notesReminderAt);
       const migrateLegacy =
         legacyText.trim().length > 0 ||
-        legacyTitle.trim().length > 0 ||
-        legacyReminderMinutes > 0 ||
-        Number.isFinite(legacyReminderAt);
+        legacyTitle.trim().length > 0;
       if (migrateLegacy) {
         let width = Number.isFinite(legacyBox.width) ? legacyBox.width : DEFAULT_CARD_WIDTH;
         let height = Number.isFinite(legacyBox.height) ? legacyBox.height : DEFAULT_CARD_HEIGHT;
@@ -84,8 +78,6 @@ export function load() {
             Number.isFinite(legacyOpts.padding) && legacyOpts.padding >= 0
               ? Math.round(legacyOpts.padding)
               : NOTE_DEFAULT_PADDING,
-          reminderMinutes: legacyReminderMinutes,
-          reminderAt: legacyReminderAt,
         };
         const pos = Math.max(
           0,
@@ -137,11 +129,6 @@ export function load() {
               hSize: g.hSize || sizeFromHeight(height),
               fontSize,
               padding,
-              reminderMinutes:
-                Number.isFinite(g.reminderMinutes) && g.reminderMinutes > 0
-                  ? Math.max(0, Math.round(g.reminderMinutes))
-                  : 0,
-              reminderAt: sanitizeTimestamp(g.reminderAt),
             };
           }
 

--- a/tests/notes-migration.test.js
+++ b/tests/notes-migration.test.js
@@ -42,8 +42,8 @@ test('legacy notes duomenys migruojami į note tipo kortelę', () => {
   assert.equal(note.color, '#fef08a');
   assert.equal(note.width, 400);
   assert.equal(note.height, 260);
-  assert.equal(note.reminderMinutes, 5);
-  assert.ok(Number.isFinite(note.reminderAt));
+  assert.ok(!('reminderMinutes' in note));
+  assert.ok(!('reminderAt' in note));
   assert.ok(!('notes' in state));
 
   globalThis.localStorage = originalStorage;


### PR DESCRIPTION
## Summary
- remove reminder controls from the notes dialog and prevent reminders from being saved with note cards
- clean loaded state and normalization logic so note cards no longer store or schedule reminders while keeping item reminders intact
- refresh legacy migration tests and documentation to reflect the new behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c95e61b3688320bb74f861d3953b53