### PR TITLE
Ensure imported dashboards refresh header metadata

### DIFF
--- a/app.js
+++ b/app.js
@@ -905,6 +905,15 @@ function importJson(file) {
         throw new Error(T.invalidImport);
       state = data;
       normaliseReminderState();
+      const importedTitle =
+        typeof state.title === 'string' ? state.title.trim() : '';
+      state.title = importedTitle || DEFAULT_TITLE;
+      const importedIcon =
+        typeof state.icon === 'string' ? state.icon.trim() : '';
+      state.icon = importedIcon;
+      pageTitleEl.textContent = state.title || DEFAULT_TITLE;
+      pageIconEl.textContent = state.icon || '';
+      document.title = state.title || DEFAULT_TITLE;
       persistState();
       renderAll();
     } catch (err) {


### PR DESCRIPTION
## Summary
- normalise imported dashboard titles/icons to safe defaults
- refresh the header text and browser tab immediately after importing JSON

## Testing
- npm test
- Manual JSON import via Playwright harness

------
https://chatgpt.com/codex/tasks/task_e_68c9b1025bcc83208df4229739cc6b68