### PR TITLE
Handle stats count for empty note groups

### DIFF
--- a/render.js
+++ b/render.js
@@ -1,4 +1,5 @@
 import { SIZE_MAP, sizeFromWidth, sizeFromHeight } from './sizes.js';
+import { countGroupItems } from './stats.js';
 
 let currentState;
 let persist;
@@ -1317,7 +1318,7 @@ export function render(state, editing, T, I, handlers, saveFn) {
   });
 
   const totalGroups = state.groups.length;
-  const totalItems = state.groups.reduce((sum, g) => sum + g.items.length, 0);
+  const totalItems = countGroupItems(state.groups);
   statsEl.textContent = `${totalGroups} grupės • ${totalItems} įrašai`;
 }
 

--- a/stats.js
+++ b/stats.js
@@ -1,0 +1,12 @@
+/**
+ * Suskaičiuoja bendrą grupių elementų skaičių, ignoruojant tuščias ar neturinčias sąrašo grupes.
+ * @param {Array} groups
+ * @returns {number}
+ */
+export function countGroupItems(groups = []) {
+  if (!Array.isArray(groups)) return 0;
+  return groups.reduce((sum, group) => {
+    const items = Array.isArray(group?.items) ? group.items : [];
+    return sum + items.length;
+  }, 0);
+}

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { countGroupItems } from '../stats.js';
+
+test('countGroupItems ignores groups without items arrays', () => {
+  const groups = [
+    { id: 'a', items: [{ id: 1 }, { id: 2 }] },
+    { id: 'b' },
+    { id: 'c', items: null },
+    { id: 'd', items: [{ id: 3 }, { id: 4 }, { id: 5 }] },
+  ];
+  assert.equal(countGroupItems(groups), 5);
+});
+
+test('countGroupItems returns 0 for invalid input', () => {
+  assert.equal(countGroupItems(), 0);
+  assert.equal(countGroupItems(null), 0);
+});


### PR DESCRIPTION
## Summary
- guard the dashboard totals against groups that do not yet contain an items array
- centralize the group item counting logic for reuse and add a regression unit test

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9c438ab08832098131a328c6dc91a