### PR TITLE
Allow zero padding in notes dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Grupių kortelių matmenys nustatomi per `style` atributus ir saugomi naršyklė
 (`group.width`, `group.height`, `notesBox.width`, `notesBox.height`).
 Numatyti matmenys – 360×360 px.
 
-Pastabų kortelės pagal nutylėjimą naudoja 20 px šriftą ir 20 px paraštes.
+Pastabų kortelės pagal nutylėjimą naudoja 20 px šriftą ir 20 px paraštes. Jei reikia nuimti paraštes visiškai, įveskite reikšmę „0“ – ji bus išsaugota ir rodoma kortelėje.
 
 ## Smoke test
 

--- a/forms.js
+++ b/forms.js
@@ -470,8 +470,10 @@ export function notesDialog(
     const cancel = form.querySelector('[data-act="cancel"]');
     form.title.value = data.title || '';
     form.note.value = data.text || '';
-    form.size.value = data.size || 20;
-    form.padding.value = data.padding || 20;
+    const initSize = Number.parseInt(data.size, 10);
+    const initPadding = Number.parseInt(data.padding, 10);
+    form.size.value = Number.isFinite(initSize) ? initSize : 20;
+    form.padding.value = Number.isFinite(initPadding) ? initPadding : 20;
     form.color.value = data.color || '#fef08a';
 
     function cleanup() {
@@ -483,11 +485,13 @@ export function notesDialog(
 
     function submit(e) {
       e.preventDefault();
+      const sizeVal = Number.parseInt(form.size.value, 10);
+      const paddingVal = Number.parseInt(form.padding.value, 10);
       resolve({
         title: form.title.value.trim(),
         text: form.note.value.trim(),
-        size: parseInt(form.size.value, 10) || 20,
-        padding: parseInt(form.padding.value, 10) || 20,
+        size: Number.isFinite(sizeVal) ? sizeVal : 20,
+        padding: Number.isFinite(paddingVal) ? paddingVal : 20,
         color: form.color.value || '#fef08a',
       });
       cleanup();


### PR DESCRIPTION
## Summary
- keep numeric zero values when loading and submitting note dialog fields
- document in the README that note padding can be set to 0 and retained

## Testing
- npm test
- manual UI check: create note with padding 0 and confirm card shows no padding

------
https://chatgpt.com/codex/tasks/task_e_68ca41458e1083209b90e90b04d97ea6