### PR TITLE
Handle overdue reminders with negative timers

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -43,6 +43,8 @@ export const Tlt = {
   reminderTypeCustom: 'Individualus priminimas',
   reminderDue: 'Laikas',
   reminderLeft: 'Liko',
+  reminderOverdue: 'Pavėluota',
+  reminderOverdueAria: 'Priminimas pavėluotas',
   reminderRemove: 'Atšaukti',
   reminderSnoozeShort: 'Atidėti',
   reminderEditInline: 'Keisti',

--- a/styles.css
+++ b/styles.css
@@ -630,11 +630,28 @@ a.item {
     flex-shrink: 0;
   }
 
+.reminder-items li.overdue .reminder-progress {
+  background:
+    conic-gradient(
+      var(--danger) calc(var(--ratio, 0) * 360deg),
+      rgba(255, 255, 255, 0.08) 0
+    );
+  color: var(--btn-danger-text);
+}
+
 .theme-light .reminder-progress {
   background:
     conic-gradient(
       var(--accent) calc(var(--ratio, 0) * 360deg),
       rgba(0, 0, 0, 0.06) 0
+    );
+}
+
+.theme-light .reminder-items li.overdue .reminder-progress {
+  background:
+    conic-gradient(
+      var(--danger) calc(var(--ratio, 0) * 360deg),
+      rgba(0, 0, 0, 0.08) 0
     );
 }
 


### PR DESCRIPTION
## Summary
- allow reminder timers to display negative durations instead of clamping to zero
- mark overdue reminders with progress metadata and improved aria labels for accessibility
- style overdue reminder rings with the danger color palette for stronger contrast

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ca4ebc3cc4832089bcda42ccccebd3