### PR TITLE
Add collapsible quick timer section

### DIFF
--- a/app.js
+++ b/app.js
@@ -205,6 +205,7 @@ function normaliseReminderState() {
       height: SIZE_MAP.md.height,
       wSize: 'md',
       hSize: 'md',
+      showQuick: true,
     };
   } else {
     const fallbackWidth = SIZE_MAP[state.remindersCard.wSize || 'md']?.width || 360;
@@ -223,6 +224,7 @@ function normaliseReminderState() {
         ? state.remindersCard.title
         : '';
     state.remindersCard.enabled = Boolean(state.remindersCard.enabled);
+    state.remindersCard.showQuick = state.remindersCard.showQuick !== false;
   }
   if (typeof state.remindersPos !== 'number') state.remindersPos = 0;
   const groups = Array.isArray(state.groups) ? state.groups : [];
@@ -535,6 +537,7 @@ function addRemindersCard() {
       height: SIZE_MAP.md.height,
       wSize: 'md',
       hSize: 'md',
+      showQuick: true,
     };
   } else {
     state.remindersCard.enabled = true;

--- a/storage.js
+++ b/storage.js
@@ -208,6 +208,7 @@ export function load() {
           height,
           wSize: sizeFromWidth(width),
           hSize: sizeFromHeight(height),
+          showQuick: true,
         };
       } else {
         data.remindersCard.enabled = Boolean(data.remindersCard.enabled);
@@ -219,6 +220,7 @@ export function load() {
           data.remindersCard.wSize || sizeFromWidth(data.remindersCard.width);
         data.remindersCard.hSize =
           data.remindersCard.hSize || sizeFromHeight(data.remindersCard.height);
+        data.remindersCard.showQuick = data.remindersCard.showQuick !== false;
       }
       if (typeof data.remindersPos !== 'number') data.remindersPos = 0;
     }
@@ -242,6 +244,7 @@ export function seed() {
       height: DEFAULT_CARD_HEIGHT,
       wSize: sizeFromWidth(DEFAULT_CARD_WIDTH),
       hSize: sizeFromHeight(DEFAULT_CARD_HEIGHT),
+      showQuick: true,
     },
     remindersPos: 0,
     customReminders: [],

--- a/styles.css
+++ b/styles.css
@@ -423,17 +423,53 @@ a.item {
   }
 
   .reminder-quick-start {
+    padding: 0;
+  }
+
+  .reminder-quick-details {
     display: grid;
-    grid-template-columns: minmax(0, 1fr);
     gap: 6px;
+    padding: 8px;
+    grid-template-columns: minmax(0, 1fr);
     align-items: start;
   }
 
-  @media (min-width: 640px) {
-    .reminder-quick-start {
-      grid-template-columns: minmax(0, 1fr) auto;
-      align-items: center;
-    }
+  .reminder-quick-summary {
+    grid-column: 1 / -1;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 6px;
+    cursor: pointer;
+    font-size: 0.875rem;
+    font-weight: 600;
+    list-style: none;
+    padding: 4px 0;
+  }
+
+  .reminder-quick-summary::-webkit-details-marker,
+  .reminder-quick-summary::marker {
+    display: none;
+  }
+
+  .reminder-quick-summary::after {
+    content: '';
+    width: 0.5rem;
+    height: 0.5rem;
+    border-right: 2px solid currentColor;
+    border-bottom: 2px solid currentColor;
+    transform: rotate(45deg);
+    transition: transform 0.2s ease;
+  }
+
+  .reminder-quick-details[open] .reminder-quick-summary::after {
+    transform: rotate(225deg);
+  }
+
+  .reminder-quick-summary:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    border-radius: 8px;
   }
 
   .reminder-quick-text {
@@ -441,6 +477,7 @@ a.item {
     flex-direction: column;
     gap: 2px;
     min-width: 0;
+    grid-column: 1;
   }
 
 @media (min-width: 768px) {
@@ -502,9 +539,19 @@ a.item {
   .reminder-quick-buttons {
     justify-content: flex-start;
     min-width: 0;
+    grid-column: 1;
   }
 
   @media (min-width: 640px) {
+    .reminder-quick-details[open] {
+      grid-template-columns: minmax(0, 1fr) auto;
+      align-items: center;
+    }
+
+    .reminder-quick-details[open] .reminder-quick-buttons {
+      grid-column: 2;
+    }
+
     .reminder-quick-buttons {
       justify-content: flex-end;
     }


### PR DESCRIPTION
## Summary
- wrap the reminders quick timer UI in a `<details>` element with a "Greiti laikmačiai" summary while keeping existing quick actions
- persist the quick timer expansion state on the reminders card so it survives re-renders
- restyle the quick timer header to remove the default marker and match the card design

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca59813e7c832092743c0e4aaa2098