### PR TITLE
Normalize reminders quick section closed by default

### DIFF
--- a/app.js
+++ b/app.js
@@ -205,7 +205,7 @@ function normaliseReminderState() {
       height: SIZE_MAP.md.height,
       wSize: 'md',
       hSize: 'md',
-      showQuick: true,
+      showQuick: false,
     };
   } else {
     const fallbackWidth = SIZE_MAP[state.remindersCard.wSize || 'md']?.width || 360;
@@ -224,7 +224,7 @@ function normaliseReminderState() {
         ? state.remindersCard.title
         : '';
     state.remindersCard.enabled = Boolean(state.remindersCard.enabled);
-    state.remindersCard.showQuick = state.remindersCard.showQuick !== false;
+    state.remindersCard.showQuick = state.remindersCard.showQuick === true;
   }
   if (typeof state.remindersPos !== 'number') state.remindersPos = 0;
   const groups = Array.isArray(state.groups) ? state.groups : [];
@@ -537,7 +537,7 @@ function addRemindersCard() {
       height: SIZE_MAP.md.height,
       wSize: 'md',
       hSize: 'md',
-      showQuick: true,
+      showQuick: false,
     };
   } else {
     state.remindersCard.enabled = true;

--- a/i18n.js
+++ b/i18n.js
@@ -35,7 +35,7 @@ export const Tlt = {
   reminderCreate: 'Pridėti',
   reminderUpdate: 'Išsaugoti priminimą',
   reminderCancelEdit: 'Atšaukti',
-  reminderQuickTitle: 'Greiti laikmačiai',
+  reminderQuickTitle: 'Greiti laikmačiai (išskleiskite santrauką)',
   reminderQuickDescription: 'Pradėti laikmatį vienu paspaudimu',
   remindersUpcoming: 'Aktyvūs priminimai',
   reminderTypeNotes: 'Pastabų kortelė',

--- a/render.js
+++ b/render.js
@@ -511,11 +511,11 @@ export function render(state, editing, T, I, handlers, saveFn) {
       quickSection.className = 'reminder-quick-start';
       const quickDetails = document.createElement('details');
       quickDetails.className = 'reminder-quick-details';
-      quickDetails.open = cardState.showQuick !== false;
+      quickDetails.open = cardState.showQuick === true;
       const quickSummary = document.createElement('summary');
       quickSummary.className = 'reminder-quick-summary';
       quickSummary.textContent =
-        T.reminderQuickTitle || 'Greiti laikmačiai';
+        T.reminderQuickTitle || 'Greiti laikmačiai (išskleiskite)';
       quickDetails.appendChild(quickSummary);
       const quickText = document.createElement('div');
       quickText.className = 'reminder-quick-text';

--- a/storage.js
+++ b/storage.js
@@ -208,7 +208,7 @@ export function load() {
           height,
           wSize: sizeFromWidth(width),
           hSize: sizeFromHeight(height),
-          showQuick: true,
+          showQuick: false,
         };
       } else {
         data.remindersCard.enabled = Boolean(data.remindersCard.enabled);
@@ -220,7 +220,7 @@ export function load() {
           data.remindersCard.wSize || sizeFromWidth(data.remindersCard.width);
         data.remindersCard.hSize =
           data.remindersCard.hSize || sizeFromHeight(data.remindersCard.height);
-        data.remindersCard.showQuick = data.remindersCard.showQuick !== false;
+        data.remindersCard.showQuick = data.remindersCard.showQuick === true;
       }
       if (typeof data.remindersPos !== 'number') data.remindersPos = 0;
     }
@@ -244,7 +244,7 @@ export function seed() {
       height: DEFAULT_CARD_HEIGHT,
       wSize: sizeFromWidth(DEFAULT_CARD_WIDTH),
       hSize: sizeFromHeight(DEFAULT_CARD_HEIGHT),
-      showQuick: true,
+      showQuick: false,
     },
     remindersPos: 0,
     customReminders: [],


### PR DESCRIPTION
## Summary
- default the reminders quick panel to closed state across storage normalization, seeding and runtime helpers while preserving previously saved choices
- ensure new reminder cards created through the UI start with showQuick disabled
- clarify the quick presets summary copy so users know the controls are hidden under the summary

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca7abf0bc083208ce70a864240ffa7