### PR TITLE
Improve mobile layout spacing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -983,3 +983,103 @@ textarea::placeholder {
     min-width: 170px;
   }
 }
+
+@media (max-width: 720px) {
+  header {
+    grid-template-columns: 1fr;
+    padding: 12px;
+    gap: 8px;
+  }
+
+  .title {
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .controls {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+  }
+
+  .controls > * {
+    width: 100%;
+  }
+
+  .controls button,
+  .controls .btn {
+    justify-content: center;
+  }
+
+  .search {
+    width: 100%;
+  }
+
+  .search input {
+    width: 100%;
+    min-width: 0;
+  }
+
+  #addMenu {
+    width: 100%;
+  }
+
+  #addMenuList {
+    position: static;
+    width: 100%;
+    margin-top: 4px;
+  }
+
+  main {
+    padding: 12px;
+  }
+
+  .grid {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .group {
+    width: 100% !important;
+    max-width: 100%;
+    min-width: 0;
+    height: auto !important;
+  }
+
+  .items-scroll {
+    padding: 10px;
+  }
+
+  .item {
+    flex-wrap: wrap;
+    align-items: flex-start;
+    gap: 6px;
+  }
+
+  .item .actions {
+    display: flex;
+    margin-left: 0;
+    width: 100%;
+    justify-content: flex-end;
+  }
+}
+
+@media (max-width: 480px) {
+  button,
+  .btn {
+    padding: 9px 10px;
+  }
+
+  .title h1 {
+    font-size: clamp(18px, 5vw, 22px);
+  }
+
+  .group-header {
+    padding: 10px;
+  }
+
+  .items-scroll {
+    padding: 8px;
+  }
+}


### PR DESCRIPTION
## Summary
- stack header controls vertically and allow inputs to span full width on narrow screens
- ensure dashboard groups fill the viewport width and collapse unused height on mobile devices
- tighten spacing for phone view so cards and lists sit closer together

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1647c17408320ac62d01964857f15