### PR TITLE
Adjust mobile layout for header controls

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -998,13 +998,14 @@ textarea::placeholder {
 
   .controls {
     width: 100%;
-    flex-direction: column;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto auto;
     align-items: stretch;
-    gap: 8px;
+    gap: 6px;
   }
 
   .controls > * {
-    width: 100%;
+    width: auto;
   }
 
   .controls button,
@@ -1019,6 +1020,23 @@ textarea::placeholder {
   .search input {
     width: 100%;
     min-width: 0;
+  }
+
+  #editBtn,
+  #themeBtn {
+    align-self: stretch;
+  }
+
+  #themeBtn {
+    justify-self: end;
+  }
+
+  .controls > *:not(.search):not(#editBtn):not(#themeBtn) {
+    grid-column: 1 / -1;
+  }
+
+  #syncStatus {
+    justify-self: start;
   }
 
   #addMenu {


### PR DESCRIPTION
## Summary
- switch the mobile header controls container to a three-column grid
- keep the search field, edit button, and theme toggle aligned on a single row while other controls span full width

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1ab60285083209ece8d168f7a685a