### PR TITLE
Fix card size classification for customizable dimensions

### DIFF
--- a/sizes.js
+++ b/sizes.js
@@ -4,14 +4,35 @@ export const SIZE_MAP = {
   lg: { width: 480, height: 480 },
 };
 
+function sizeFromDimension(value, dimension) {
+  const entries = Object.entries(SIZE_MAP)
+    .map(([key, dims]) => [key, Number(dims?.[dimension])])
+    .filter(([, val]) => Number.isFinite(val))
+    .sort((a, b) => a[1] - b[1]);
+
+  if (!entries.length) return 'md';
+
+  const numericValue = Number(value);
+  if (!Number.isFinite(numericValue)) {
+    return entries[0][0];
+  }
+
+  for (let i = 0; i < entries.length - 1; i += 1) {
+    const currentVal = entries[i][1];
+    const nextVal = entries[i + 1][1];
+    const midpoint = currentVal + (nextVal - currentVal) / 2;
+    if (numericValue < midpoint) {
+      return entries[i][0];
+    }
+  }
+
+  return entries[entries.length - 1][0];
+}
+
 export function sizeFromWidth(w) {
-  if (w >= 420) return 'lg';
-  if (w >= 300) return 'md';
-  return 'sm';
+  return sizeFromDimension(w, 'width');
 }
 
 export function sizeFromHeight(h) {
-  if (h >= 420) return 'lg';
-  if (h >= 300) return 'md';
-  return 'sm';
+  return sizeFromDimension(h, 'height');
 }

--- a/tests/sizes.test.js
+++ b/tests/sizes.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { sizeFromWidth, sizeFromHeight } from '../sizes.js';
+import { SIZE_MAP, sizeFromWidth, sizeFromHeight } from '../sizes.js';
 
 test('sizeFromWidth klasifikacijos', () => {
   assert.strictEqual(sizeFromWidth(240), 'sm');
@@ -19,4 +19,50 @@ test('sizeFromHeight klasifikacijos', () => {
   assert.strictEqual(sizeFromHeight(419), 'md');
   assert.strictEqual(sizeFromHeight(420), 'lg');
   assert.strictEqual(sizeFromHeight(600), 'lg');
+});
+
+test('sizeFromWidth prisitaiko prie pakeistų dydžių', (t) => {
+  const backup = Object.fromEntries(
+    Object.entries(SIZE_MAP).map(([key, dims]) => [key, { ...dims }]),
+  );
+
+  t.after(() => {
+    Object.entries(backup).forEach(([key, dims]) => {
+      if (!SIZE_MAP[key]) SIZE_MAP[key] = {};
+      Object.assign(SIZE_MAP[key], dims);
+    });
+  });
+
+  SIZE_MAP.sm.width = 200;
+  SIZE_MAP.md.width = 320;
+  SIZE_MAP.lg.width = 520;
+
+  assert.strictEqual(sizeFromWidth(180), 'sm');
+  assert.strictEqual(sizeFromWidth(259), 'sm');
+  assert.strictEqual(sizeFromWidth(260), 'md');
+  assert.strictEqual(sizeFromWidth(419), 'md');
+  assert.strictEqual(sizeFromWidth(420), 'lg');
+});
+
+test('sizeFromHeight prisitaiko prie pakeistų dydžių', (t) => {
+  const backup = Object.fromEntries(
+    Object.entries(SIZE_MAP).map(([key, dims]) => [key, { ...dims }]),
+  );
+
+  t.after(() => {
+    Object.entries(backup).forEach(([key, dims]) => {
+      if (!SIZE_MAP[key]) SIZE_MAP[key] = {};
+      Object.assign(SIZE_MAP[key], dims);
+    });
+  });
+
+  SIZE_MAP.sm.height = 200;
+  SIZE_MAP.md.height = 340;
+  SIZE_MAP.lg.height = 540;
+
+  assert.strictEqual(sizeFromHeight(199), 'sm');
+  assert.strictEqual(sizeFromHeight(269), 'sm');
+  assert.strictEqual(sizeFromHeight(270), 'md');
+  assert.strictEqual(sizeFromHeight(439), 'md');
+  assert.strictEqual(sizeFromHeight(440), 'lg');
 });


### PR DESCRIPTION
## Summary
- derive card size classification boundaries from the configured SIZE_MAP so width/height changes take effect
- extend size utility tests to cover dynamic SIZE_MAP adjustments for both width and height

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d514e53de0832095cad550325dde27