### PR TITLE
Add configurable KPI, Trend, and OKR cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,9 @@
             <button id="addChart" type="button">📈 Pridėti grafiką</button>
             <button id="addNote" type="button">＋ Pridėti pastabas</button>
             <button id="addRemindersCard" type="button">⏰ Pridėti priminimų kortelę</button>
+            <button id="addKpiCard" type="button">📊 KPI</button>
+            <button id="addTrendCard" type="button">📉 Trend</button>
+            <button id="addOkrCard" type="button">✅ OKR</button>
           </div>
         </div>
         <button


### PR DESCRIPTION
## Summary
- add KPI, Trend, and OKR shortcuts to the add menu
- implement metric creation/editing dialogs and persistence for KPI, Trend, and OKR cards
- render KPI, Trend, and OKR cards with progress, trend, and status UI while preserving editing controls

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de71667c4c8320adf6a1911c651e71