### PR TITLE
Add FLIP animations for dashboard cards

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1083,6 +1083,48 @@ textarea::placeholder {
   }
 }
 
+@keyframes card-enter {
+  from {
+    opacity: 0;
+    transform: translateY(12px) scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes card-leave {
+  from {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(12px) scale(0.96);
+  }
+}
+
+.group[data-anim='enter'],
+.item[data-anim='enter'] {
+  animation: card-enter 200ms ease-out forwards;
+}
+
+.group[data-anim='leave'],
+.item[data-anim='leave'] {
+  pointer-events: none;
+  animation: card-leave 200ms ease-in forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .group[data-anim],
+  .item[data-anim] {
+    animation: none !important;
+    transform: none !important;
+    opacity: 1 !important;
+  }
+}
+
 @media (max-width: 480px) {
   button,
   .btn {


### PR DESCRIPTION
## Summary
- add FLIP-based animations and enter transitions when rendering groups and items
- delay state changes for group, note, item, and reminder card removals until leave animations finish, with reduced-motion support
- define shared card enter/leave keyframes and reduced-motion fallbacks in CSS

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de74f1a8188320ada99f8da7faca1d