### PR TITLE
Improve add menu accessibility and animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,13 +43,35 @@
         <button id="editBtn" class="btn-outline" type="button">
           Redaguoti
         </button>
-        <div id="addMenu" style="display: none">
-          <button id="addBtn" type="button">＋ Pridėti</button>
-          <div id="addMenuList">
-            <button id="addGroup" type="button">＋ Pridėti grupę</button>
-            <button id="addChart" type="button">📈 Pridėti grafiką</button>
-            <button id="addNote" type="button">＋ Pridėti pastabas</button>
-            <button id="addRemindersCard" type="button">⏰ Pridėti priminimų kortelę</button>
+        <div id="addMenu" data-open="0" style="display: none">
+          <button
+            id="addBtn"
+            type="button"
+            aria-haspopup="true"
+            aria-expanded="false"
+            aria-controls="addMenuList"
+          >
+            ＋ Pridėti
+          </button>
+          <div class="menu-backdrop" data-menu-backdrop aria-hidden="true"></div>
+          <div
+            id="addMenuList"
+            class="menu-panel"
+            role="menu"
+            aria-labelledby="addBtn"
+          >
+            <button id="addGroup" type="button" role="menuitem">
+              ＋ Pridėti grupę
+            </button>
+            <button id="addChart" type="button" role="menuitem">
+              📈 Pridėti grafiką
+            </button>
+            <button id="addNote" type="button" role="menuitem">
+              ＋ Pridėti pastabas
+            </button>
+            <button id="addRemindersCard" type="button" role="menuitem">
+              ⏰ Pridėti priminimų kortelę
+            </button>
           </div>
         </div>
         <button

--- a/styles.css
+++ b/styles.css
@@ -149,25 +149,80 @@ header {
 
 #addMenu {
   position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
-#addMenuList {
-  display: none;
-  flex-direction: column;
+#addMenu .menu-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(8, 13, 18, 0.45);
+  backdrop-filter: blur(4px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 160ms ease;
+  z-index: 4;
+}
+
+.menu-panel {
   position: absolute;
-  top: 100%;
+  top: calc(100% + 8px);
   left: 0;
+  display: flex;
+  flex-direction: column;
+  min-width: 220px;
   background: var(--panel);
-  border: 1px solid var(--muted);
-  border-radius: 8px;
-  padding: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  padding: 8px;
   gap: 4px;
-  z-index: 10;
+  box-shadow: 0 18px 38px rgba(0, 0, 0, 0.32);
+  opacity: 0;
+  transform: scale(0.95);
+  transform-origin: top left;
+  pointer-events: none;
+  visibility: hidden;
+  transition:
+    opacity 140ms ease,
+    transform 160ms cubic-bezier(0.16, 1, 0.3, 1);
+  z-index: 5;
 }
 
-#addMenuList button {
+#addMenu[data-open='1'] .menu-backdrop {
+  opacity: 1;
+  pointer-events: auto;
+  animation: menu-fade 160ms ease;
+}
+
+#addMenu[data-open='1'] .menu-panel {
+  opacity: 1;
+  transform: scale(1);
+  pointer-events: auto;
+  visibility: visible;
+  animation: menu-pop 160ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.menu-panel button {
   width: 100%;
+  justify-content: flex-start;
   text-align: left;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  background: transparent;
+  box-shadow: none;
+  transition: background 140ms ease, color 140ms ease;
+}
+
+.menu-panel button:hover,
+.menu-panel button:focus-visible {
+  background: var(--muted);
+  color: var(--text);
+}
+
+.menu-panel button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 button,
@@ -398,6 +453,36 @@ a.item {
     padding: 8px;
     flex: 1;
   }
+
+@keyframes menu-pop {
+  from {
+    opacity: 0;
+    transform: scale(0.92);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes menu-fade {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #addMenu .menu-backdrop,
+  .menu-panel {
+    transition: none !important;
+    animation: none !important;
+  }
+}
 
   .reminder-controls {
     display: grid;


### PR DESCRIPTION
## Summary
- add backdrop and aria attributes to the add menu markup for better accessibility
- restyle the add menu panel with transitions, hover/focus-visible states, and reduced-motion handling
- refactor the add menu logic to use data attributes, close on Escape, and restore focus for keyboard users

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de7844111c83208a20fbb09c024bbb