### PR TITLE
Allow note cards to wrap text after resizing

### DIFF
--- a/render.js
+++ b/render.js
@@ -1155,6 +1155,8 @@ export function render(state, editing, T, I, handlers, saveFn) {
       itemsScroll.className = 'items-scroll';
       const p = document.createElement('p');
       p.style.whiteSpace = 'pre-wrap';
+      p.style.overflowWrap = 'anywhere';
+      p.style.wordBreak = 'break-word';
       const padding = Number.isFinite(g.padding) ? g.padding : 20;
       const fontSize = Number.isFinite(g.fontSize) ? g.fontSize : 20;
       p.style.padding = padding + 'px';

--- a/styles.css
+++ b/styles.css
@@ -374,6 +374,20 @@ main {
   padding: 8px;
   overflow: visible;
 }
+.note-card .items {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+}
+.note-card .items-scroll {
+  max-width: 100%;
+  max-height: 100%;
+  overflow: auto;
+}
+.note-card .items-scroll p {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
 .reminder-highlight {
   outline: 3px solid var(--accent);
   outline-offset: 2px;


### PR DESCRIPTION
## Summary
- ensure note cards flex their content area so resizing keeps text within bounds
- add overflow wrapping rules so long note text breaks onto new lines

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3bec03a888320a82f195d98299c2f