### PR TITLE
Refactor reminder form state handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,6 +12,11 @@ import { I } from './icons.js';
 import { Tlt } from './i18n.js';
 import { exportJson } from './exporter.js';
 import { createReminderManager } from './reminders.js';
+import {
+  getReminderFormState,
+  resetReminderFormState,
+  updateReminderFormState,
+} from './reminder-form-state.js';
 
 const T = Tlt;
 // Hook future English localisation: fill T.en when translations are ready.
@@ -27,22 +32,6 @@ const REMINDER_QUICK_MINUTES = [5, 10, 15, 30];
 const NOTE_DEFAULT_COLOR = '#fef08a';
 const NOTE_DEFAULT_FONT = 20;
 const NOTE_DEFAULT_PADDING = 20;
-
-const reminderFormDefaults = {
-  editingId: null,
-  values: null,
-  error: '',
-};
-
-let reminderFormState = { ...reminderFormDefaults };
-
-function resetReminderFormState() {
-  reminderFormState = { ...reminderFormDefaults };
-}
-
-function updateReminderFormState(partial = {}) {
-  reminderFormState = { ...reminderFormState, ...partial };
-}
 
 function formatDateTimeLocal(ts) {
   if (!Number.isFinite(ts)) return '';
@@ -594,9 +583,10 @@ function submitReminderForm(formData = {}) {
     createdAt: now,
   };
 
-  if (reminderFormState.editingId) {
+  const formState = getReminderFormState();
+  if (formState.editingId) {
     const target = (state.customReminders || []).find(
-      (item) => item.id === reminderFormState.editingId,
+      (item) => item.id === formState.editingId,
     );
     if (!target) {
       resetReminderFormState();
@@ -738,7 +728,7 @@ function renderAll() {
         edit: (entry) => editReminder(entry),
         quick: (minutes) => createQuickReminder(minutes),
         submit: (payload) => submitReminderForm(payload),
-        formState: () => reminderFormState,
+        formState: () => getReminderFormState(),
         cancelEdit: () => cancelEditCustomReminder(),
         focus: () => focusReminderCard(),
         startEditCustom: (id) => beginEditCustomReminder(id),

--- a/reminder-form-state.js
+++ b/reminder-form-state.js
@@ -1,0 +1,54 @@
+const REMINDER_FORM_DEFAULTS = Object.freeze({
+  editingId: null,
+  values: null,
+  error: '',
+});
+
+let reminderFormState = { ...REMINDER_FORM_DEFAULTS };
+
+/**
+ * Returns the current reminder form state reference.
+ * @returns {{editingId: string|null, values: object|null, error: string}}
+ */
+export function getReminderFormState() {
+  return reminderFormState;
+}
+
+/**
+ * Replaces the reminder form state with provided partial data.
+ * @param {Partial<{editingId: string|null, values: object|null, error: string}>} [partial]
+ * @returns {{editingId: string|null, values: object|null, error: string}}
+ */
+export function updateReminderFormState(partial = {}) {
+  reminderFormState = { ...reminderFormState, ...partial };
+  return reminderFormState;
+}
+
+/**
+ * Resets the reminder form state to defaults.
+ * @returns {{editingId: string|null, values: object|null, error: string}}
+ */
+export function resetReminderFormState() {
+  reminderFormState = { ...REMINDER_FORM_DEFAULTS };
+  return reminderFormState;
+}
+
+/**
+ * Sets the reminder form state to the provided snapshot.
+ * @param {{editingId?: string|null, values?: object|null, error?: string}|undefined} nextState
+ * @returns {{editingId: string|null, values: object|null, error: string}}
+ */
+export function setReminderFormState(nextState) {
+  if (nextState == null || typeof nextState !== 'object') {
+    return resetReminderFormState();
+  }
+  reminderFormState = {
+    ...REMINDER_FORM_DEFAULTS,
+    ...nextState,
+  };
+  return reminderFormState;
+}
+
+export function reminderFormDefaults() {
+  return REMINDER_FORM_DEFAULTS;
+}

--- a/tests/reminderFormState.test.js
+++ b/tests/reminderFormState.test.js
@@ -1,0 +1,45 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  getReminderFormState,
+  updateReminderFormState,
+  resetReminderFormState,
+  setReminderFormState,
+  reminderFormDefaults,
+} from '../reminder-form-state.js';
+
+const DEFAULT_STATE = reminderFormDefaults();
+
+test('reminder form state resets to defaults', () => {
+  updateReminderFormState({ editingId: 'foo', values: { a: 1 }, error: 'x' });
+  const resetState = resetReminderFormState();
+  assert.deepEqual(resetState, DEFAULT_STATE);
+  assert.equal(getReminderFormState().editingId, null);
+});
+
+test('updateReminderFormState merges partial updates', () => {
+  resetReminderFormState();
+  const firstRef = getReminderFormState();
+  updateReminderFormState({ editingId: 'abc' });
+  const afterFirstUpdate = getReminderFormState();
+  assert.notStrictEqual(firstRef, afterFirstUpdate);
+  assert.equal(afterFirstUpdate.editingId, 'abc');
+  assert.equal(afterFirstUpdate.error, '');
+  const afterSecondUpdate = updateReminderFormState({ error: 'klaida' });
+  assert.equal(afterSecondUpdate.editingId, 'abc');
+  assert.equal(afterSecondUpdate.error, 'klaida');
+});
+
+test('setReminderFormState replaces state snapshot', () => {
+  resetReminderFormState();
+  const snapshot = {
+    editingId: 'xyz',
+    values: { title: 'Testas' },
+    error: 'klaida',
+  };
+  setReminderFormState(snapshot);
+  const current = getReminderFormState();
+  assert.deepEqual(current, snapshot);
+  setReminderFormState(null);
+  assert.deepEqual(getReminderFormState(), DEFAULT_STATE);
+});


### PR DESCRIPTION
## Summary
- extract reminder form state helpers into a dedicated module
- update the main app logic to consume the new accessors
- add coverage for reminder form state helpers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3caf86afc8320b3f1e0c188f28623