### PR TITLE
Fix persistence of custom group sizes

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -44,14 +44,37 @@ function sanitizeIconImage(value) {
   return trimmed;
 }
 
+const SIZE_SNAP_TOLERANCE = 1;
+
+function shouldSnapToPreset(value, preset) {
+  if (!Number.isFinite(preset)) return false;
+  if (!Number.isFinite(value)) return true;
+  return Math.abs(Math.round(value) - Math.round(preset)) <= SIZE_SNAP_TOLERANCE;
+}
+
 function normalizeDimensionPair(width, height, wSize, hSize) {
   const widthPreset = SIZE_MAP[wSize]?.width;
   const heightPreset = SIZE_MAP[hSize]?.height;
-  const finalWidth = Number.isFinite(widthPreset) ? widthPreset : width;
-  const finalHeight = Number.isFinite(heightPreset) ? heightPreset : height;
+
+  let finalWidth;
+  if (shouldSnapToPreset(width, widthPreset)) {
+    finalWidth = Number.isFinite(widthPreset) ? Math.round(widthPreset) : undefined;
+  } else if (Number.isFinite(width)) {
+    finalWidth = Math.round(width);
+  }
+
+  let finalHeight;
+  if (shouldSnapToPreset(height, heightPreset)) {
+    finalHeight = Number.isFinite(heightPreset)
+      ? Math.round(heightPreset)
+      : undefined;
+  } else if (Number.isFinite(height)) {
+    finalHeight = Math.round(height);
+  }
+
   return {
-    width: Number.isFinite(finalWidth) ? Math.round(finalWidth) : undefined,
-    height: Number.isFinite(finalHeight) ? Math.round(finalHeight) : undefined,
+    width: finalWidth,
+    height: finalHeight,
   };
 }
 
@@ -138,9 +161,15 @@ export function load() {
       const normalisedGroups = groups
         .map((g) => {
           if (!g || typeof g !== 'object') return null;
-          let width = Number.isFinite(g.width) ? g.width : DEFAULT_CARD_WIDTH;
-          let height = Number.isFinite(g.height) ? g.height : DEFAULT_CARD_HEIGHT;
-          if (!Number.isFinite(g.width) || !Number.isFinite(g.height)) {
+          const hasWidth = Number.isFinite(g.width);
+          const hasHeight = Number.isFinite(g.height);
+          let width = hasWidth
+            ? g.width
+            : SIZE_MAP[g.wSize ?? g.size]?.width ?? DEFAULT_CARD_WIDTH;
+          let height = hasHeight
+            ? g.height
+            : SIZE_MAP[g.hSize ?? g.size]?.height ?? DEFAULT_CARD_HEIGHT;
+          if (!hasWidth || !hasHeight) {
             if (g.size === 'sm') {
               width = 240;
               height = 240;

--- a/tests/notes-migration.test.js
+++ b/tests/notes-migration.test.js
@@ -40,8 +40,8 @@ test('legacy notes duomenys migruojami į note tipo kortelę', () => {
   assert.equal(note.fontSize, 18);
   assert.equal(note.padding, 12);
   assert.equal(note.color, '#fef08a');
-  assert.equal(note.width, 360);
-  assert.equal(note.height, 360);
+  assert.equal(note.width, legacyState.notesBox.width);
+  assert.equal(note.height, legacyState.notesBox.height);
   assert.ok(!('reminderMinutes' in note));
   assert.ok(!('reminderAt' in note));
   assert.ok(!('notes' in state));

--- a/tests/storage-sizes.test.js
+++ b/tests/storage-sizes.test.js
@@ -1,0 +1,96 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { SIZE_MAP } from '../sizes.js';
+import { load } from '../storage.js';
+
+const STORAGE_KEY = 'ed_dashboard_lt_v1';
+
+function withFakeStorage(state, callback) {
+  const fakeStorage = {
+    getItem(key) {
+      assert.equal(key, STORAGE_KEY);
+      return JSON.stringify(state);
+    },
+  };
+  const originalStorage = globalThis.localStorage;
+  globalThis.localStorage = fakeStorage;
+  try {
+    return callback();
+  } finally {
+    globalThis.localStorage = originalStorage;
+  }
+}
+
+test('link group custom dydžiai išsaugomi', () => {
+  const customState = {
+    groups: [
+      {
+        id: 'group-1',
+        type: 'link',
+        name: 'Test',
+        width: 520,
+        height: 410,
+        wSize: 'lg',
+        hSize: 'lg',
+        sizePreset: { width: null, height: null },
+        customWidth: 520,
+        customHeight: 410,
+        items: [],
+      },
+    ],
+    title: 'Skydelis',
+  };
+
+  const state = withFakeStorage(customState, () => load());
+  assert.equal(state.groups[0].width, 520);
+  assert.equal(state.groups[0].height, 410);
+  assert.equal(state.groups[0].wSize, 'lg');
+  assert.equal(state.groups[0].hSize, 'lg');
+  assert.equal(state.groups[0].sizePreset.width, null);
+  assert.equal(state.groups[0].sizePreset.height, null);
+  assert.equal(state.groups[0].customWidth, 520);
+  assert.equal(state.groups[0].customHeight, 410);
+});
+
+test('trūkstami dydžiai nukrenta į iš anksto nustatytas reikšmes', () => {
+  const fallbackState = {
+    groups: [
+      {
+        id: 'group-2',
+        type: 'link',
+        name: 'Fallback',
+        wSize: 'md',
+        hSize: 'sm',
+        items: [],
+      },
+    ],
+    title: 'Skydelis',
+  };
+
+  const state = withFakeStorage(fallbackState, () => load());
+  assert.equal(state.groups[0].width, SIZE_MAP.md.width);
+  assert.equal(state.groups[0].height, SIZE_MAP.sm.height);
+});
+
+test('vertės arti šablono prilyginamos presetui', () => {
+  const almostPresetState = {
+    groups: [
+      {
+        id: 'group-3',
+        type: 'link',
+        name: 'Almost preset',
+        width: SIZE_MAP.md.width + 1,
+        height: SIZE_MAP.md.height - 1,
+        wSize: 'md',
+        hSize: 'md',
+        items: [],
+      },
+    ],
+    title: 'Skydelis',
+  };
+
+  const state = withFakeStorage(almostPresetState, () => load());
+  assert.equal(state.groups[0].width, SIZE_MAP.md.width);
+  assert.equal(state.groups[0].height, SIZE_MAP.md.height);
+});


### PR DESCRIPTION
## Summary
- keep custom group widths/heights when normalising stored data so link groups keep their layout after refresh
- add regression tests covering storage sizing logic and adjust the legacy notes migration test to match the new behaviour

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d9a2e77ac8320b2d81b686421303e)