### PR TITLE
Add Supabase project setup artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Statinis HTML + ES moduliais paremtas prietaisų skydas, skirtas greitam informa
 
 ## Supabase integracija
 - [docs/supabase-integration-plan.md](docs/supabase-integration-plan.md) – nuoseklus 8 žingsnių planas, kaip pridėti Supabase autentifikaciją ir nustatymų sinchronizaciją (lentelės SQL, failų pakeitimai, smoke testai).
+- `supabase/schema.sql` ir `supabase/README.md` – pirmojo etapo (projekto paruošimas) failai: lentelės `ed_dash_settings` SQL, RLS politika, Email OTP įjungimo ir smoke test instrukcijos.
 - Rekomenduojama kiekvieną etapą diegti atskirai ir po sėkmės žymėti releasus (`v0.2.0-alpha1`, `v0.2.0-alpha2`, …), kad būtų paprasta grįžti į stabilų lokalų režimą, jei nuotolinis saugojimas sukeltų trikdžių.
 
 ## Licencija

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -1,0 +1,24 @@
+# Supabase projekto paruošimas
+
+Šis katalogas saugo pirmojo integracijos etapo ("Supabase projekto paruošimas") artefaktus. Instrukcijos remiasi `docs/supabase-integration-plan.md`.
+
+## 1. Projekto kūrimas
+1. Supabase valdymo pulte sukurkite naują projektą arba pasirinkite esamą organizaciją.
+2. Pasirinkite regioną, kuriame laikysite ED skyriaus nustatymus.
+3. Įgalinkite **Email OTP** autentifikaciją skiltyje `Authentication → Providers` ir sukonfigūruokite SMTP, kad OTP laiškai būtų pristatomi.
+
+## 2. Schema ir RLS
+1. Atsisiųskite `schema.sql` iš šio katalogo.
+2. SQL paleiskite per Supabase SQL editorių (arba CLI):
+   ```bash
+   supabase db execute --file supabase/schema.sql
+   ```
+3. Patvirtinkite, kad atsirado lentelė `ed_dash_settings`, įjungtas RLS ir indeksas `idx_ed_dash_settings_user_id`.
+
+## 3. Smoke test
+1. Per Supabase Auth UI sukurkite testinį vartotoją.
+2. Rankiniu būdu įterpkite vieną `ed_dash_settings` eilutę su to vartotojo `user_id` ir pavyzdiniu `state_json`.
+3. Prisijunkite naudodami tą vartotoją ir SQL editoriuje patikrinkite, ar jis mato tik savo eilutę (RLS veikia).
+
+## 4. Kas toliau?
+Tolimesni etapai (konfigūracija, klientas, UI ir t. t.) aprašyti `docs/supabase-integration-plan.md`. Užbaigus šį etapą galite kurti vietinį `supabase-config.js` failą pagal kitos užduoties reikalavimus.

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,15 @@
+-- Supabase ED dashboard schema (stage 1)
+create table if not exists ed_dash_settings (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users (id) on delete cascade,
+  state_json jsonb not null default '{}'::jsonb,
+  updated_at timestamptz not null default now()
+);
+
+alter table ed_dash_settings enable row level security;
+
+create policy "Users can manage their state" on ed_dash_settings
+  for all using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create index if not exists idx_ed_dash_settings_user_id on ed_dash_settings(user_id);


### PR DESCRIPTION
## Summary
- add a Supabase schema file and README to capture the Stage 1 setup instructions
- document the new Supabase setup files in the main README

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691db63a032883208700a50c9a56c57c)