### PR TITLE
Add Supabase client module

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,3 +1,4 @@
+import { initSupabase } from './supabase-client.js';
 import { load, save, seed } from './storage.js';
 import { render, updateEditingUI, toSheetEmbed } from './render.js';
 import { SIZE_MAP, sizeFromWidth, sizeFromHeight } from './sizes.js';
@@ -20,7 +21,6 @@ import {
   updateReminderFormState,
 } from './reminder-form-state.js';
 import {
-  REMINDER_MODE_NONE,
   REMINDER_MODE_DATETIME,
   REMINDER_MODE_MINUTES,
   parseReminderInput,
@@ -42,6 +42,36 @@ const NOTE_DEFAULT_PADDING = 20;
 const MAX_ICON_IMAGE_BYTES = 200 * 1024; // 200 KB
 const MAX_ICON_IMAGE_LENGTH = Math.ceil((MAX_ICON_IMAGE_BYTES / 3) * 4) + 512;
 const ICON_IMAGE_ACCEPT_PREFIX = 'data:image/';
+
+const supabaseConfigPromise = import('./supabase-config.js')
+  .then((module) => {
+    const url = module?.SUPABASE_URL;
+    const anonKey = module?.SUPABASE_ANON_KEY;
+    if (!url || !anonKey) {
+      console.warn(
+        'Supabase konfigūracija nepilna – naudokite vietinį režimą arba užpildykite supabase-config.js.'
+      );
+      return null;
+    }
+    return { url, anonKey };
+  })
+  .catch((error) => {
+    console.warn(
+      'Supabase konfigūracijos failas nerastas. Naudojamas tik vietinis režimas.',
+      error
+    );
+    return null;
+  });
+
+supabaseConfigPromise.then((config) => {
+  if (config) {
+    try {
+      initSupabase({ url: config.url, anonKey: config.anonKey });
+    } catch (error) {
+      console.error('Nepavyko inicijuoti Supabase kliento:', error);
+    }
+  }
+});
 
 function sanitizeIconImage(value) {
   if (typeof value !== 'string') return '';

--- a/render.js
+++ b/render.js
@@ -370,14 +370,18 @@ function cleanupIntrinsicState(cardEl) {
     state.observers.forEach((disconnect) => {
       try {
         disconnect();
-      } catch {}
+      } catch (error) {
+        console.warn('Nepavyko atjungti kortelės stebėtojo', error);
+      }
     });
     state.observers = [];
   }
   if (state.removalCleanup) {
     try {
       state.removalCleanup();
-    } catch {}
+    } catch (error) {
+      console.warn('Nepavyko išvalyti kortelės šalinimo funkcijos', error);
+    }
     state.removalCleanup = null;
   }
   intrinsicPendingCards.delete(cardEl);
@@ -410,7 +414,9 @@ function ensureIntrinsicState(cardEl, innerEl = findCardInnerElement(cardEl)) {
       state.observers.forEach((disconnect) => {
         try {
           disconnect();
-        } catch {}
+        } catch (error) {
+          console.warn('Nepavyko atnaujinti kortelės stebėtojo', error);
+        }
       });
     }
     state.observers = [];
@@ -724,7 +730,9 @@ function initResizeHandles(cardEl) {
     if (activeResize && activeResize.el === cardEl && cardEl.releasePointerCapture) {
       try {
         cardEl.releasePointerCapture(activeResize.pointerId);
-      } catch {}
+      } catch (error) {
+        console.warn('Nepavyko atleisti pointer capture', error);
+      }
     }
     cardEl.removeEventListener('pointermove', handlePointerMove);
     cardEl.removeEventListener('pointerup', handlePointerUp);
@@ -742,7 +750,9 @@ function initResizeHandles(cardEl) {
     if (cardEl.setPointerCapture && Number.isFinite(event.pointerId)) {
       try {
         cardEl.setPointerCapture(event.pointerId);
-      } catch {}
+      } catch (error) {
+        console.warn('Nepavyko priskirti pointer capture', error);
+      }
     }
     cardEl.addEventListener('pointermove', handlePointerMove);
     cardEl.addEventListener('pointerup', handlePointerUp);
@@ -785,7 +795,9 @@ function setupMinSizeWatcher(cardEl, innerEl) {
   if (state.removalCleanup) {
     try {
       state.removalCleanup();
-    } catch {}
+    } catch (error) {
+      console.warn('Nepavyko išvalyti ankstesnio stebėjimo', error);
+    }
     state.removalCleanup = null;
   }
 
@@ -794,7 +806,9 @@ function setupMinSizeWatcher(cardEl, innerEl) {
     if (state.removalCleanup) {
       try {
         state.removalCleanup();
-      } catch {}
+      } catch (error) {
+        console.warn('Nepavyko perkurti stebėtojo (parent)', error);
+      }
       state.removalCleanup = null;
     }
     const removalObserver = new MutationObserver(() => {

--- a/supabase-client.js
+++ b/supabase-client.js
@@ -1,0 +1,109 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+let supabase = null;
+
+function resolveConfig(input = {}) {
+  if (!input || typeof input !== 'object') {
+    return { url: null, anonKey: null };
+  }
+  const url =
+    input.url ||
+    input.supabaseUrl ||
+    input.SUPABASE_URL ||
+    null;
+  const anonKey =
+    input.anonKey ||
+    input.supabaseAnonKey ||
+    input.SUPABASE_ANON_KEY ||
+    null;
+  return { url, anonKey };
+}
+
+function ensureClient() {
+  if (!supabase) {
+    throw new Error(
+      'Supabase klientas neinicijuotas. Patikrinkite supabase-config.js nustatymus.'
+    );
+  }
+  return supabase;
+}
+
+export function initSupabase(config = {}) {
+  const { url, anonKey } = resolveConfig(config);
+  if (!url || !anonKey) {
+    console.warn(
+      'Supabase konfigūracija nepilna – klientas nebuvo sukurtas (naudojamas tik vietinis režimas).'
+    );
+    supabase = null;
+    return null;
+  }
+  supabase = createClient(url, anonKey);
+  return supabase;
+}
+
+export async function signInWithOtp(email) {
+  const client = ensureClient();
+  const normalizedEmail = typeof email === 'string' ? email.trim() : '';
+  if (!normalizedEmail) {
+    throw new Error('El. pašto adresas privalomas OTP prisijungimui.');
+  }
+  const { data, error } = await client.auth.signInWithOtp({ email: normalizedEmail });
+  if (error) throw error;
+  return data;
+}
+
+export async function signOut() {
+  const client = ensureClient();
+  const { error } = await client.auth.signOut();
+  if (error) throw error;
+  return true;
+}
+
+export function getSession() {
+  const client = ensureClient();
+  return client.auth.getSession();
+}
+
+export async function fetchSettings() {
+  const client = ensureClient();
+  const { data, error } = await client
+    .from('ed_dash_settings')
+    .select('id, user_id, state_json, updated_at')
+    .single();
+  if (error) {
+    if (error.code === 'PGRST116') {
+      return null;
+    }
+    throw error;
+  }
+  return data;
+}
+
+export async function upsertSettings(payload = {}) {
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('Supabase išsaugojimui būtinas objekto tipo payload.');
+  }
+  const client = ensureClient();
+  const { data, error } = await client
+    .from('ed_dash_settings')
+    .upsert(payload)
+    .select()
+    .single();
+  if (error) throw error;
+  return data;
+}
+
+const publicApi = {
+  initSupabase,
+  signInWithOtp,
+  signOut,
+  getSession,
+  fetchSettings,
+  upsertSettings,
+};
+
+if (typeof window !== 'undefined') {
+  window.supabaseClient = publicApi;
+}
+
+export default publicApi;


### PR DESCRIPTION
## Summary
- add a reusable Supabase client wrapper with auth and settings helpers
- initialize the client from `app.js` using dynamic imports so the UI can stay offline-first when no config is present
- log cleanup errors from intrinsic layout helpers to satisfy lint rules

## Testing
- `npm run lint`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691db93122048320bd7b0564ad34cce7)