### PR TITLE
Lazy load Supabase SDK

### DIFF
--- a/app.js
+++ b/app.js
@@ -75,7 +75,7 @@ const supabaseConfigPromise = import('./supabase-config.js')
 supabaseConfigPromise.then(async (config) => {
   if (config) {
     try {
-      initSupabase({ url: config.url, anonKey: config.anonKey });
+      await initSupabase({ url: config.url, anonKey: config.anonKey });
       supabaseReady = true;
       updateAuthButtonState();
       await refreshAuthSession();

--- a/supabase-client.js
+++ b/supabase-client.js
@@ -1,6 +1,17 @@
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
-
 let supabase = null;
+let supabaseModulePromise = null;
+
+async function loadSupabaseModule() {
+  if (!supabaseModulePromise) {
+    supabaseModulePromise = import('https://esm.sh/@supabase/supabase-js@2').catch(
+      (error) => {
+        supabaseModulePromise = null;
+        throw error;
+      }
+    );
+  }
+  return supabaseModulePromise;
+}
 
 function resolveConfig(input = {}) {
   if (!input || typeof input !== 'object') {
@@ -28,7 +39,7 @@ function ensureClient() {
   return supabase;
 }
 
-export function initSupabase(config = {}) {
+export async function initSupabase(config = {}) {
   const { url, anonKey } = resolveConfig(config);
   if (!url || !anonKey) {
     console.warn(
@@ -37,7 +48,8 @@ export function initSupabase(config = {}) {
     supabase = null;
     return null;
   }
-  supabase = createClient(url, anonKey);
+  const module = await loadSupabaseModule();
+  supabase = module.createClient(url, anonKey);
   return supabase;
 }
 


### PR DESCRIPTION
## Summary
- load the Supabase client SDK dynamically so that offline/local mode no longer blocks app startup
- await the asynchronous Supabase initialisation during auth setup

## Testing
- `npm test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dd10a99908320bc5d5bf0d7a8c84a)