### PR TITLE
Enable automatic Supabase sync

### DIFF
--- a/app.js
+++ b/app.js
@@ -116,7 +116,21 @@ function ensureStateMeta(targetState) {
   if (!source.meta || typeof source.meta !== 'object') {
     source.meta = {};
   }
+  if (!('remoteUpdatedAt' in source.meta)) {
+    source.meta.remoteUpdatedAt = null;
+  }
+  if (!('remoteId' in source.meta)) {
+    source.meta.remoteId = null;
+  }
   return source.meta;
+}
+
+function resolveAuthUserId() {
+  const userId = authSession?.user?.id;
+  if (typeof userId === 'string' && userId) {
+    return userId;
+  }
+  return null;
 }
 
 function formatDateTimeLocal(ts) {
@@ -522,7 +536,16 @@ async function bootstrapSession() {
         meta.remoteUpdatedAt = null;
         shouldPersist = true;
       }
+      if (meta.remoteId) {
+        meta.remoteId = null;
+        shouldPersist = true;
+      }
       return { appliedRemote: false };
+    }
+    const remoteId = typeof remote.id === 'string' && remote.id ? remote.id : null;
+    if (meta.remoteId !== remoteId) {
+      meta.remoteId = remoteId;
+      shouldPersist = true;
     }
     const remoteState =
       remote.state_json && typeof remote.state_json === 'object' ? remote.state_json : null;
@@ -1574,6 +1597,33 @@ function canSyncRemoteState() {
   return supabaseReady && Boolean(authSession?.user);
 }
 
+async function ensureRemoteRowId() {
+  const userId = resolveAuthUserId();
+  if (!userId) {
+    return { userId: null, rowId: null };
+  }
+  const meta = ensureStateMeta();
+  if (typeof meta.remoteId === 'string' && meta.remoteId) {
+    return { userId, rowId: meta.remoteId };
+  }
+  try {
+    const remote = await fetchSettings();
+    const remoteId = typeof remote?.id === 'string' && remote.id ? remote.id : null;
+    if (remoteId) {
+      meta.remoteId = remoteId;
+      const remoteUpdatedAt =
+        typeof remote?.updated_at === 'string' && remote.updated_at ? remote.updated_at : null;
+      if (remoteUpdatedAt) {
+        meta.remoteUpdatedAt = remoteUpdatedAt;
+      }
+      return { userId, rowId: remoteId };
+    }
+  } catch (error) {
+    console.warn('Nepavyko nustatyti Supabase įrašo ID:', error);
+  }
+  return { userId, rowId: userId };
+}
+
 function clearRemoteSaveTimer() {
   if (remoteSaveTimer) {
     clearTimeout(remoteSaveTimer);
@@ -1613,15 +1663,25 @@ async function remoteSave(snapshot) {
   if (!canSyncRemoteState()) return;
   const targetState = snapshot || cloneStateSnapshot(state);
   if (!targetState) return;
+  const { userId, rowId } = await ensureRemoteRowId();
+  if (!userId) {
+    console.warn('Nuotolinio išsaugojimo vartotojo ID nerastas – sinchronizacija nutraukta.');
+    return;
+  }
   const issuedAtIso = new Date().toISOString();
   try {
     setSyncStatus(T.authStatusSyncing || 'Sinchronizuojama…');
     const result = await upsertSettings({
+      id: rowId,
+      user_id: userId,
       state_json: targetState,
       updated_at: issuedAtIso,
     });
     const remoteUpdatedAt = result?.updated_at || issuedAtIso;
-    ensureStateMeta().remoteUpdatedAt = remoteUpdatedAt;
+    const meta = ensureStateMeta();
+    meta.remoteUpdatedAt = remoteUpdatedAt;
+    const savedRemoteId = typeof result?.id === 'string' && result.id ? result.id : rowId;
+    meta.remoteId = savedRemoteId;
     save(state);
     const email = authSession?.user?.email || '';
     if (email) {

--- a/app.js
+++ b/app.js
@@ -286,6 +286,8 @@ let editing = false;
 let reminders;
 let debouncedSearchRender = null;
 let remoteSaveTimer = null;
+let remoteSaveInFlight = false;
+let remoteSavePendingSnapshot = null;
 
 normaliseReminderState();
 
@@ -1660,6 +1662,27 @@ function debounceRemoteSave(nextState) {
 }
 
 async function remoteSave(snapshot) {
+  if (!canSyncRemoteState()) return;
+  const targetState = snapshot || cloneStateSnapshot(state);
+  if (!targetState) return;
+  remoteSavePendingSnapshot = targetState;
+  if (remoteSaveInFlight) return;
+  remoteSaveInFlight = true;
+  try {
+    while (remoteSavePendingSnapshot && canSyncRemoteState()) {
+      const nextSnapshot = remoteSavePendingSnapshot;
+      remoteSavePendingSnapshot = null;
+      await performRemoteSaveRequest(nextSnapshot);
+    }
+  } finally {
+    remoteSaveInFlight = false;
+    if (remoteSavePendingSnapshot && canSyncRemoteState()) {
+      await remoteSave(remoteSavePendingSnapshot);
+    }
+  }
+}
+
+async function performRemoteSaveRequest(snapshot) {
   if (!canSyncRemoteState()) return;
   const targetState = snapshot || cloneStateSnapshot(state);
   if (!targetState) return;

--- a/app.js
+++ b/app.js
@@ -5,8 +5,9 @@ import {
   getSession,
   onAuthStateChange,
   fetchSettings,
+  upsertSettings,
 } from './supabase-client.js';
-import { load, save, seed } from './storage.js';
+import { load, save, seed, touchState } from './storage.js';
 import { render, updateEditingUI, toSheetEmbed } from './render.js';
 import { SIZE_MAP, sizeFromWidth, sizeFromHeight } from './sizes.js';
 import {
@@ -50,6 +51,8 @@ const MAX_ICON_IMAGE_BYTES = 200 * 1024; // 200 KB
 const MAX_ICON_IMAGE_LENGTH = Math.ceil((MAX_ICON_IMAGE_BYTES / 3) * 4) + 512;
 const ICON_IMAGE_ACCEPT_PREFIX = 'data:image/';
 const AUTH_EMAIL_STORAGE_KEY = 'ed_dash_last_email';
+const REMOTE_SAVE_DEBOUNCE_MS = 2000;
+const REMOTE_SAVE_ERROR_MESSAGE = 'Nepavyko išsaugoti – bandykite rankiniu būdu';
 
 let supabaseReady = false;
 
@@ -268,6 +271,7 @@ if (state.iconImage) state.icon = '';
 let editing = false;
 let reminders;
 let debouncedSearchRender = null;
+let remoteSaveTimer = null;
 
 normaliseReminderState();
 
@@ -749,6 +753,9 @@ function updateAuthSession(session) {
     if (wasAuthenticated) {
       scheduleAuthModalAutoOpen();
     }
+  }
+  if (!authSession) {
+    clearRemoteSaveTimer();
   }
   updateAuthButtonState();
 }
@@ -1563,12 +1570,78 @@ function syncReminders() {
   updateReminderBadge(entries.length);
 }
 
+function canSyncRemoteState() {
+  return supabaseReady && Boolean(authSession?.user);
+}
+
+function clearRemoteSaveTimer() {
+  if (remoteSaveTimer) {
+    clearTimeout(remoteSaveTimer);
+    remoteSaveTimer = null;
+  }
+}
+
+function cloneStateSnapshot(input) {
+  if (!input || typeof input !== 'object') return null;
+  if (typeof structuredClone === 'function') {
+    try {
+      return structuredClone(input);
+    } catch (error) {
+      console.warn('Nepavyko sukurti būsenos kopijos structuredClone metodu:', error);
+    }
+  }
+  try {
+    return JSON.parse(JSON.stringify(input));
+  } catch (error) {
+    console.error('Nuotolinio išsaugojimo būsenos kopijavimo klaida:', error);
+    return null;
+  }
+}
+
+function debounceRemoteSave(nextState) {
+  if (!canSyncRemoteState()) return;
+  const snapshot = cloneStateSnapshot(nextState);
+  if (!snapshot) return;
+  clearRemoteSaveTimer();
+  remoteSaveTimer = setTimeout(() => {
+    remoteSaveTimer = null;
+    remoteSave(snapshot);
+  }, REMOTE_SAVE_DEBOUNCE_MS);
+}
+
+async function remoteSave(snapshot) {
+  if (!canSyncRemoteState()) return;
+  const targetState = snapshot || cloneStateSnapshot(state);
+  if (!targetState) return;
+  const issuedAtIso = new Date().toISOString();
+  try {
+    setSyncStatus(T.authStatusSyncing || 'Sinchronizuojama…');
+    const result = await upsertSettings({
+      state_json: targetState,
+      updated_at: issuedAtIso,
+    });
+    const remoteUpdatedAt = result?.updated_at || issuedAtIso;
+    ensureStateMeta().remoteUpdatedAt = remoteUpdatedAt;
+    save(state);
+    const email = authSession?.user?.email || '';
+    if (email) {
+      setSyncStatus(formatSignedInStatus(email), { variant: 'success' });
+    } else {
+      setSyncStatus(T.authStatusSignedIn || 'Prisijungęs', { variant: 'success' });
+    }
+  } catch (error) {
+    console.error('Nuotolinio išsaugojimo klaida:', error);
+    setSyncStatus(REMOTE_SAVE_ERROR_MESSAGE, { variant: 'error' });
+  }
+}
+
 function persistState() {
   normaliseReminderState();
-  state.updatedAt = Date.now();
+  touchState(state);
   ensureStateMeta();
   save(state);
   syncReminders();
+  debounceRemoteSave(state);
 }
 
 function renderAll() {

--- a/app.js
+++ b/app.js
@@ -533,6 +533,8 @@ async function bootstrapSession() {
   try {
     const remote = await fetchSettings();
     const meta = ensureStateMeta();
+    const hadRemoteId = typeof meta.remoteId === 'string' && meta.remoteId;
+    const localHasContent = Array.isArray(state.groups) && state.groups.length > 0;
     if (!remote) {
       if (meta.remoteUpdatedAt) {
         meta.remoteUpdatedAt = null;
@@ -545,6 +547,7 @@ async function bootstrapSession() {
       return { appliedRemote: false };
     }
     const remoteId = typeof remote.id === 'string' && remote.id ? remote.id : null;
+    const remoteIdChanged = Boolean(hadRemoteId && remoteId && hadRemoteId !== remoteId);
     if (meta.remoteId !== remoteId) {
       meta.remoteId = remoteId;
       shouldPersist = true;
@@ -555,15 +558,17 @@ async function bootstrapSession() {
       typeof remote.updated_at === 'string' && remote.updated_at ? remote.updated_at : null;
     const remoteUpdatedAtValue = remoteUpdatedAtIso ? Date.parse(remoteUpdatedAtIso) : null;
     const localUpdatedAt = Number.isFinite(state.updatedAt) ? state.updatedAt : 0;
+    const isFreshLocalState = !hadRemoteId && !localHasContent;
+    const shouldApplyRemote =
+      remoteState &&
+      (remoteIdChanged ||
+        isFreshLocalState ||
+        (Number.isFinite(remoteUpdatedAtValue) && remoteUpdatedAtValue > localUpdatedAt));
     if (meta.remoteUpdatedAt !== remoteUpdatedAtIso) {
       meta.remoteUpdatedAt = remoteUpdatedAtIso;
       shouldPersist = true;
     }
-    if (
-      remoteState &&
-      Number.isFinite(remoteUpdatedAtValue) &&
-      remoteUpdatedAtValue > localUpdatedAt
-    ) {
+    if (shouldApplyRemote) {
       Object.assign(state, remoteState);
       if (!Number.isFinite(state.updatedAt) || state.updatedAt < remoteUpdatedAtValue) {
         state.updatedAt = remoteUpdatedAtValue;

--- a/storage.js
+++ b/storage.js
@@ -369,6 +369,9 @@ export function load() {
           ? data.meta.remoteUpdatedAt
           : null;
       data.meta.remoteUpdatedAt = remoteUpdatedAt;
+      const remoteId =
+        typeof data.meta.remoteId === 'string' && data.meta.remoteId ? data.meta.remoteId : null;
+      data.meta.remoteId = remoteId;
     }
     return data;
   } catch (e) {
@@ -430,6 +433,7 @@ export function seed() {
     updatedAt: now,
     meta: {
       remoteUpdatedAt: null,
+      remoteId: null,
     },
   };
   save(data);

--- a/storage.js
+++ b/storage.js
@@ -376,7 +376,18 @@ export function load() {
   }
 }
 
+export function touchState(target, timestamp = Date.now()) {
+  if (!target || typeof target !== 'object') return null;
+  const nextTimestamp = Number.isFinite(timestamp) ? Math.round(timestamp) : Date.now();
+  target.updatedAt = nextTimestamp;
+  return nextTimestamp;
+}
+
 export function save(state) {
+  if (!state || typeof state !== 'object') return;
+  if (!Number.isFinite(state.updatedAt)) {
+    touchState(state);
+  }
   localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
 }
 


### PR DESCRIPTION
## Summary
- add a debounced remote save flow that upserts dashboard state to Supabase whenever `persistState()` runs
- update the storage helper to expose `touchState()` so the `updatedAt` timestamp is refreshed before every save

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dddf827c083209f7c48c5830b4a96)