### PR TITLE
Add Supabase sync documentation and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## v0.2.0 - Supabase sinchronizacija (planas)
+- Parengtas Supabase integracijos planas su testais ir dokumentacija.
+- Pridėtas automatizuotas tikrinimas, kad nuotolinė sinchronizacija vykdoma tik prisijungusiam vartotojui.
+- Atnaujintas README su Supabase diegimo/rollback nuorodomis ir naujas `test:supabase` scenarijus.

--- a/README.md
+++ b/README.md
@@ -116,5 +116,11 @@ Statinis HTML + ES moduliais paremtas prietaisų skydas, skirtas greitam informa
 - `supabase/schema.sql` ir `supabase/README.md` – pirmojo etapo (projekto paruošimas) failai: lentelės `ed_dash_settings` SQL, RLS politika, Email autentifikacijos ir smoke test instrukcijos.
 - Rekomenduojama kiekvieną etapą diegti atskirai ir po sėkmės žymėti releasus (`v0.2.0-alpha1`, `v0.2.0-alpha2`, …), kad būtų paprasta grįžti į stabilų lokalų režimą, jei nuotolinis saugojimas sukeltų trikdžių.
 
+### Kaip įjungti Supabase
+1. Nukopijuokite konfigūraciją: `cp supabase-config.example.js supabase-config.js` ir užpildykite `SUPABASE_URL`, `SUPABASE_ANON_KEY`. Failas neįtraukiamas į git, todėl raktažodžiai lieka lokaliai.
+2. Patikrinkite [docs/supabase-integration-plan.md](docs/supabase-integration-plan.md) – žingsniai nuo projekto SQL iki UI prisijungimo ir sinchronizavimo.
+3. Paleiskite kokybės patikras: `npm test`, `npm run lint`, `npm run format` arba tik Supabase scenarijų `npm run test:supabase`.
+4. Jei reikia atsukti pakeitimus („How to rollback“): naudokite paskutinę žymą, pvz., `git checkout v0.1.0` (lokalus režimas) arba `git checkout v0.2.0-alpha<N>` (Supabase etapai).
+
 ## Licencija
 Projektas platinamas pagal [MIT licenciją](LICENSE).

--- a/app.js
+++ b/app.js
@@ -1905,6 +1905,32 @@ function persistState() {
   debounceRemoteSave(state);
 }
 
+export const __testHooks = {
+  setStateForTest(nextState) {
+    state = nextState;
+  },
+  setAuthSessionForTest(session) {
+    authSession = session;
+  },
+  setSupabaseReadyForTest(nextReady) {
+    supabaseReady = Boolean(nextReady);
+  },
+  resetRemoteSaveForTest() {
+    clearRemoteSaveTimer();
+    remoteSavePendingSnapshot = null;
+    remoteSaveInFlight = false;
+  },
+  getRemoteSaveTimerForTest() {
+    return remoteSaveTimer;
+  },
+  persistStateForTest() {
+    persistState();
+  },
+  async flushRemoteSaveForTest(snapshot) {
+    await remoteSave(snapshot);
+  },
+};
+
 function renderAll() {
   if (typeof debouncedSearchRender?.cancel === 'function') {
     debouncedSearchRender.cancel();

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "app.js",
   "scripts": {
     "test": "node --test tests",
+    "test:supabase": "node --test tests/supabase-sync.test.js",
     "lint": "eslint .",
     "format": "prettier --write ."
   },

--- a/supabase-client.js
+++ b/supabase-client.js
@@ -1,3 +1,11 @@
+function resolveTestMock(methodName) {
+  const mock = globalThis.__supabaseClientMock;
+  if (mock && typeof mock[methodName] === 'function') {
+    return mock[methodName];
+  }
+  return null;
+}
+
 let supabase = null;
 let supabaseModulePromise = null;
 
@@ -40,6 +48,8 @@ function ensureClient() {
 }
 
 export async function initSupabase(config = {}) {
+  const mockFn = resolveTestMock('initSupabase');
+  if (mockFn) return mockFn(config);
   const { url, anonKey } = resolveConfig(config);
   if (!url || !anonKey) {
     console.warn(
@@ -54,6 +64,8 @@ export async function initSupabase(config = {}) {
 }
 
 export async function signInWithPassword(email, password) {
+  const mockFn = resolveTestMock('signInWithPassword');
+  if (mockFn) return mockFn(email, password);
   const client = ensureClient();
   const normalizedEmail = typeof email === 'string' ? email.trim() : '';
   const normalizedPassword = typeof password === 'string' ? password : '';
@@ -69,6 +81,8 @@ export async function signInWithPassword(email, password) {
 }
 
 export async function signOut() {
+  const mockFn = resolveTestMock('signOut');
+  if (mockFn) return mockFn();
   const client = ensureClient();
   const { error } = await client.auth.signOut();
   if (error) throw error;
@@ -76,11 +90,15 @@ export async function signOut() {
 }
 
 export function getSession() {
+  const mockFn = resolveTestMock('getSession');
+  if (mockFn) return mockFn();
   const client = ensureClient();
   return client.auth.getSession();
 }
 
 export function onAuthStateChange(callback) {
+  const mockFn = resolveTestMock('onAuthStateChange');
+  if (mockFn) return mockFn(callback);
   const client = ensureClient();
   if (typeof callback !== 'function') {
     throw new Error('Auth būsenos stebėjimui būtina nurodyti funkciją.');
@@ -89,6 +107,8 @@ export function onAuthStateChange(callback) {
 }
 
 export async function fetchSettings() {
+  const mockFn = resolveTestMock('fetchSettings');
+  if (mockFn) return mockFn();
   const client = ensureClient();
   const { data, error } = await client
     .from('ed_dash_settings')
@@ -104,6 +124,8 @@ export async function fetchSettings() {
 }
 
 export async function upsertSettings(payload = {}) {
+  const mockFn = resolveTestMock('upsertSettings');
+  if (mockFn) return mockFn(payload);
   if (!payload || typeof payload !== 'object') {
     throw new Error('Supabase išsaugojimui būtinas objekto tipo payload.');
   }

--- a/tests/supabase-sync.test.js
+++ b/tests/supabase-sync.test.js
@@ -1,0 +1,159 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const supabaseCalls = { upsert: 0 };
+
+const supabaseMock = {
+  initSupabase: async () => ({}),
+  signInWithPassword: async () => ({}),
+  signOut: async () => true,
+  getSession: async () => ({ data: { session: null } }),
+  onAuthStateChange: () => ({ data: { subscription: { unsubscribe: () => {} } } }),
+  fetchSettings: async () => ({
+    id: 'row-1',
+    user_id: 'user-1',
+    state_json: null,
+    updated_at: new Date().toISOString(),
+  }),
+  upsertSettings: async (payload) => {
+    supabaseCalls.upsert += 1;
+    return {
+      id: payload.id || 'row-1',
+      updated_at: payload.updated_at || new Date().toISOString(),
+    };
+  },
+};
+
+function createStubElement() {
+  const noop = () => {};
+  const base = {
+    addEventListener: noop,
+    removeEventListener: noop,
+    setAttribute: noop,
+    getAttribute: () => null,
+    querySelector: () => null,
+    querySelectorAll: () => [],
+    appendChild: noop,
+    remove: noop,
+    classList: { add: noop, remove: noop, toggle: noop, contains: () => false },
+    style: {},
+    focus: noop,
+    blur: noop,
+    click: noop,
+    value: '',
+    innerHTML: '',
+    textContent: '',
+  };
+  return new Proxy(base, {
+    get(target, prop) {
+      if (prop in target) return target[prop];
+      return noop;
+    },
+  });
+}
+
+function setupDomStubs() {
+  const element = createStubElement();
+  const doc = {
+    documentElement: { classList: element.classList },
+    body: element,
+    createElement: () => createStubElement(),
+    createDocumentFragment: () => createStubElement(),
+    getElementById: () => createStubElement(),
+    querySelector: () => createStubElement(),
+    querySelectorAll: () => [],
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  };
+  globalThis.document = doc;
+  globalThis.window = {
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    getSelection: () => ({ removeAllRanges: () => {} }),
+    matchMedia: () => ({ matches: false, addEventListener: () => {}, removeEventListener: () => {} }),
+    navigator: { language: 'lt-LT' },
+  };
+  globalThis.DOMParser = class {
+    parseFromString() {
+      return { querySelector: () => null };
+    }
+  };
+  globalThis.localStorage = {
+    getItem: () => null,
+    setItem: () => {},
+    removeItem: () => {},
+  };
+  globalThis.alert = () => {};
+  globalThis.confirm = () => true;
+  globalThis.HTMLElement = class {};
+  globalThis.requestAnimationFrame = (cb) => {
+    if (typeof cb === 'function') cb();
+    return 0;
+  };
+}
+
+function createMinimalState() {
+  return {
+    groups: [],
+    customReminders: [],
+    remindersCard: {
+      enabled: false,
+      title: '',
+      wSize: 'md',
+      hSize: 'md',
+      showQuick: false,
+      width: 360,
+      height: 360,
+    },
+    meta: {},
+  };
+}
+
+async function loadAppModule() {
+  if (!globalThis.__appModule) {
+    setupDomStubs();
+    globalThis.__supabaseClientMock = supabaseMock;
+    globalThis.__appModule = await import('../app.js');
+  }
+  return globalThis.__appModule;
+}
+
+test('persistState nesiunčia į Supabase neprisijungus', async (t) => {
+  supabaseCalls.upsert = 0;
+  try {
+    const app = await loadAppModule();
+    const hooks = app.__testHooks;
+
+    hooks.resetRemoteSaveForTest();
+    hooks.setSupabaseReadyForTest(true);
+    hooks.setAuthSessionForTest(null);
+    hooks.setStateForTest(createMinimalState());
+
+    hooks.persistStateForTest();
+    assert.equal(hooks.getRemoteSaveTimerForTest(), null);
+    await hooks.flushRemoteSaveForTest();
+    assert.equal(supabaseCalls.upsert, 0);
+  } finally {
+    supabaseCalls.upsert = 0;
+  }
+});
+
+test('persistState kviečia nuotolinį išsaugojimą, kai vartotojas prisijungęs', async (t) => {
+  supabaseCalls.upsert = 0;
+  try {
+    const app = await loadAppModule();
+    const hooks = app.__testHooks;
+
+    hooks.resetRemoteSaveForTest();
+    hooks.setSupabaseReadyForTest(true);
+    hooks.setAuthSessionForTest({ user: { id: 'user-99', email: 'test@example.com' } });
+    hooks.setStateForTest(createMinimalState());
+
+    hooks.persistStateForTest();
+    assert.ok(hooks.getRemoteSaveTimerForTest());
+    await hooks.flushRemoteSaveForTest();
+    assert.equal(supabaseCalls.upsert, 1);
+  } finally {
+    supabaseCalls.upsert = 0;
+  }
+});


### PR DESCRIPTION
## Summary
- add Supabase integration quickstart details and changelog entry
- allow Supabase client mocking and expose test hooks for remote sync
- add targeted Supabase sync unit test and npm script

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e152ec35c83209a99e61366904226)