### PR TITLE
Prevent pending remote save from overwriting fetched Supabase state

### DIFF
--- a/app.js
+++ b/app.js
@@ -1710,6 +1710,7 @@ async function remoteFetchLatest() {
       updateIdleSyncStatus();
       return;
     }
+    clearPendingRemoteSave();
     const remoteId = typeof remote.id === 'string' && remote.id ? remote.id : null;
     const applied = applyRemoteState(remoteState, {
       remoteId,
@@ -1816,6 +1817,11 @@ function clearRemoteSaveTimer() {
   }
 }
 
+function clearPendingRemoteSave() {
+  clearRemoteSaveTimer();
+  remoteSavePendingSnapshot = null;
+}
+
 function cloneStateSnapshot(input) {
   if (!input || typeof input !== 'object') return null;
   if (typeof structuredClone === 'function') {
@@ -1916,8 +1922,7 @@ export const __testHooks = {
     supabaseReady = Boolean(nextReady);
   },
   resetRemoteSaveForTest() {
-    clearRemoteSaveTimer();
-    remoteSavePendingSnapshot = null;
+    clearPendingRemoteSave();
     remoteSaveInFlight = false;
   },
   getRemoteSaveTimerForTest() {


### PR DESCRIPTION
## Summary
- clear any pending remote save timers and queued snapshots before applying freshly fetched Supabase state
- add a helper to reset pending remote saves and reuse it in test hooks

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e182118d08320a49dfcc3a00a3cfa)