### PR TITLE
Simplify Supabase sync flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Statinis HTML + ES moduliais paremtas prietaisų skydas, skirtas greitam informa
 ## Trumpai
 - Kortelės nuorodoms, grafiko įterpiniams, pastaboms ir priminimams su drag-and-drop bei rankenomis dydžiui keisti.
 - Klaviatūros trumpiniai (`/`, `Ctrl+K`, `?`) ir pagalbos modalas greitam darbui.
-- JSON eksportas/importas atsarginėms kopijoms; pasirenkamas Google Sheets sinchronizavimas.
+- Automatinė Supabase sinchronizacija prisijungus (be rankinių mygtukų), pasirenkamas Google Sheets sinchronizavimas.
 - Lengvai keičiamas puslapio pavadinimas, emoji ar paveikslėlio ikona, šviesi/tamsi tema ir CSS akcentų spalvos.
 
 ## Naudojimas
@@ -59,18 +59,16 @@ Statinis HTML + ES moduliais paremtas prietaisų skydas, skirtas greitam informa
 - Visi spalvų tokenai ir semantiniai kintamieji aprašyti `styles/base.css`.
 
 ## Duomenų saugojimas ir atsarginės kopijos
-- Būsena saugoma `localStorage` po raktu `ed_dashboard_lt_v1` (grupės, įrašai, priminimai, pavadinimas, ikonos, temos nustatymai).
-- **Duomenų meniu**: mygtukas „Duomenys“ redagavimo režime išskleidžia importo ir eksporto parinktis.
-- **Eksportas**: parinktis „Eksportuoti“ išsaugo JSON failą (`<pavadinimas>-<timestamp>.json`).
-- **Importas**: parinktis „Importuoti“ leidžia pasirinkti anksčiau eksportuotą JSON; importuojant atnaujinamas pavadinimas, ikona, kortelės, priminimai.
+- Būsena saugoma `localStorage` po raktu `ed_dashboard_lt_v1` (grupės, įrašai, priminimai, pavadinimas, ikonos, temos nustatymai) ir automatiškai sinchronizuojama su Supabase, kai tik prisijungiate.
+- Prisijungus puslapis visada parsisiunčia naujausią Supabase būseną ir toliau siunčia pakeitimus foniniu režimu.
 - **Google Sheets** (pasirenkama):
   1. `storage.js` faile atnaujinkite `SCRIPT_URL` į savo Apps Script „web app“ adresą.
-  2. `app.js` faile atkomentuokite `const sheets = sheetsSync(...)` ir prijunkite `sheets.export()`/`sheets.import()` prie reikiamų mygtukų.
+  2. Jei reikia papildomos atsarginės kopijos, `app.js` faile atkomentuokite `const sheets = sheetsSync(...)` ir iškvieskite `sheets.export()`/`sheets.import()` savo logikoje.
   3. Apps Script turėtų palaikyti `action: "export" | "import"` ir grąžinti JSON struktūrą, atitinkančią `storage.js` tipą.
 
 ## Privatumas ir leidimai
 - Primenimų pranešimai gali būti matomi užrakintame įrenginyje – prieš įjungdami įsitikinkite, kad tai leidžia skyriuje galiojančios taisyklės.
-- Visa informacija išlieka vartotojo naršyklėje; jokių duomenų automatiškai nesiunčiama į serverius.
+- Visa informacija išlieka vartotojo naršyklėje; jei Supabase konfigūruotas ir esate prisijungę, duomenys automatiškai siunčiami į Supabase kaip atsarginė kopija.
 - „Clear data“ atlikite iš naršyklės „Application → Local Storage“ ar paspaudę `localStorage.removeItem('ed_dashboard_lt_v1')` konsolėje.
 
 ## Klaviatūros trumpiniai
@@ -103,7 +101,7 @@ Statinis HTML + ES moduliais paremtas prietaisų skydas, skirtas greitam informa
 6. Priskirkite priminimą konkrečiam įrašui ir patikrinkite, ar kortelė gauna žymeklį ⏰.
 7. Perjunkite šviesią/tamsią temą, įkelkite antraštės paveikslėlį ir išvalykite ikoną.
 8. Naudodami paiešką suraskite įrašą, išvalykite lauką per „Išvalyti“ mygtuką.
-9. Atlikite JSON eksportą, išvalykite `localStorage`, importuokite failą ir patikrinkite, ar visos kortelės bei priminimai atsistatė.
+9. Prisijunkite prie Supabase, atnaujinkite puslapį ir patikrinkite, ar automatiškai užkraunami bei išsaugomi naujausi duomenys.
 
 ## Našumo profilis (Chrome Performance)
 1. Atidarykite aplikaciją Chrome naršyklėje ir įjunkite **DevTools** (`Ctrl+Shift+I`).

--- a/app.js
+++ b/app.js
@@ -23,11 +23,9 @@ import {
   confirmDialog as confirmDlg,
   notesDialog,
   helpDialog,
-  remoteSyncDialog,
 } from './forms.js';
 import { I } from './icons.js';
 import { Tlt } from './i18n.js';
-import { exportJson } from './exporter.js';
 import { createReminderManager } from './reminders.js';
 import {
   getReminderFormState,
@@ -227,11 +225,6 @@ const searchClearBtn = document.getElementById('searchClear');
 const pageIconImageBtn = document.getElementById('pageIconImageBtn');
 const pageIconClearBtn = document.getElementById('pageIconClearBtn');
 const pageIconFileInput = document.getElementById('pageIconFile');
-const dataMenu = document.getElementById('dataMenu');
-const dataMenuBtn = document.getElementById('dataMenuBtn');
-const dataMenuList = document.getElementById('dataMenuList');
-const remoteFetchBtn = document.getElementById('remoteFetchBtn');
-const remotePushBtn = document.getElementById('remotePushBtn');
 let pageIconImageEl = null;
 
 let authSession = null;
@@ -240,12 +233,11 @@ let authModalOpen = false;
 let authSubmitting = false;
 let lastFocusedBeforeAuthModal = null;
 let autoAuthModalRequested = true;
+let bootstrapCompleted = false;
 
 applyPageIconActionLabels();
-applyDataMenuLabels();
 applyAuthLabels();
 updateAuthButtonState();
-updateRemoteSyncButtons();
 
 if (addMenu && !addMenu.dataset.open) {
   addMenu.dataset.open = '0';
@@ -259,19 +251,6 @@ if (addBtn) {
   }
   addBtn.setAttribute('aria-expanded', addMenu?.dataset.open === '1' ? 'true' : 'false');
 }
-if (dataMenu && !dataMenu.dataset.open) {
-  dataMenu.dataset.open = '0';
-}
-if (dataMenuBtn) {
-  if (!dataMenuBtn.hasAttribute('aria-controls')) {
-    dataMenuBtn.setAttribute('aria-controls', 'dataMenuList');
-  }
-  if (!dataMenuBtn.hasAttribute('aria-haspopup')) {
-    dataMenuBtn.setAttribute('aria-haspopup', 'true');
-  }
-  dataMenuBtn.setAttribute('aria-expanded', dataMenu?.dataset.open === '1' ? 'true' : 'false');
-}
-
 let state = load() || seed();
 bootstrapSession()
   .then((result) => {
@@ -284,6 +263,9 @@ bootstrapSession()
   })
   .catch((error) => {
     console.error('Nepavyko užbaigti Supabase paleidimo:', error);
+  })
+  .finally(() => {
+    bootstrapCompleted = true;
   });
 if (!Array.isArray(state.groups)) state.groups = [];
 if (!state.title) state.title = DEFAULT_TITLE;
@@ -400,30 +382,6 @@ function applyPageIconActionLabels() {
   }
 }
 
-function applyDataMenuLabels() {
-  if (!dataMenu) return;
-  const menuLabel = dataMenuBtn?.querySelector('[data-menu-label]');
-  if (menuLabel) {
-    menuLabel.textContent = T.dataMenu || 'Duomenys';
-  }
-  const importLabel = dataMenu.querySelector('[data-menu-import] span');
-  if (importLabel) {
-    importLabel.textContent = T.import || 'Importuoti';
-  }
-  const exportLabel = dataMenu.querySelector('[data-menu-export] span');
-  if (exportLabel) {
-    exportLabel.textContent = T.export || 'Eksportuoti';
-  }
-  const remoteFetchLabel = dataMenu.querySelector('[data-menu-remote-fetch] span');
-  if (remoteFetchLabel) {
-    remoteFetchLabel.textContent = T.remoteFetch || 'Atsiųsti iš Supabase';
-  }
-  const remotePushLabel = dataMenu.querySelector('[data-menu-remote-push] span');
-  if (remotePushLabel) {
-    remotePushLabel.textContent = T.remotePush || 'Išsiųsti į Supabase';
-  }
-}
-
 function applyAuthLabels() {
   if (authToggleBtn) {
     const label = T.authToggleSignIn || 'Prisijungti';
@@ -488,23 +446,6 @@ function setSyncStatus(message, options = {}) {
   } else {
     delete syncStatusEl.dataset.variant;
   }
-}
-
-function updateRemoteSyncButtons() {
-  const canSync = canSyncRemoteState();
-  const disabledTitle = !supabaseReady
-    ? T.authNoConfig || ''
-    : T.remoteSyncAuthRequired || T.authToggleSignIn || '';
-  [remoteFetchBtn, remotePushBtn].forEach((btn) => {
-    if (!btn) return;
-    btn.disabled = !canSync;
-    if (btn.hasAttribute('aria-disabled')) {
-      btn.setAttribute('aria-disabled', canSync ? 'false' : 'true');
-    } else if (!canSync) {
-      btn.setAttribute('aria-disabled', 'true');
-    }
-    btn.title = canSync ? '' : disabledTitle;
-  });
 }
 
 function updateIdleSyncStatus() {
@@ -594,66 +535,9 @@ async function bootstrapSession() {
     maybeAutoOpenAuthModal();
     return { appliedRemote: false };
   }
-  let shouldPersist = false;
-  let remoteApplied = false;
-  try {
-    const remote = await fetchSettings();
-    const meta = ensureStateMeta();
-    const hadRemoteId = typeof meta.remoteId === 'string' && meta.remoteId;
-    const localHasContent = Array.isArray(state.groups) && state.groups.length > 0;
-    if (!remote) {
-      if (meta.remoteUpdatedAt) {
-        meta.remoteUpdatedAt = null;
-        shouldPersist = true;
-      }
-      if (meta.remoteId) {
-        meta.remoteId = null;
-        shouldPersist = true;
-      }
-      return { appliedRemote: false };
-    }
-    const remoteId = typeof remote.id === 'string' && remote.id ? remote.id : null;
-    const remoteIdChanged = Boolean(hadRemoteId && remoteId && hadRemoteId !== remoteId);
-    if (meta.remoteId !== remoteId) {
-      meta.remoteId = remoteId;
-      shouldPersist = true;
-    }
-    const remoteState =
-      remote.state_json && typeof remote.state_json === 'object' ? remote.state_json : null;
-    const remoteUpdatedAtIso =
-      typeof remote.updated_at === 'string' && remote.updated_at ? remote.updated_at : null;
-    const remoteUpdatedAtValue = remoteUpdatedAtIso ? Date.parse(remoteUpdatedAtIso) : null;
-    const localUpdatedAt = Number.isFinite(state.updatedAt) ? state.updatedAt : 0;
-    const isFreshLocalState = !hadRemoteId && !localHasContent;
-    const shouldApplyRemote =
-      remoteState &&
-      (remoteIdChanged ||
-        isFreshLocalState ||
-        (Number.isFinite(remoteUpdatedAtValue) && remoteUpdatedAtValue > localUpdatedAt));
-    if (meta.remoteUpdatedAt !== remoteUpdatedAtIso) {
-      meta.remoteUpdatedAt = remoteUpdatedAtIso;
-      shouldPersist = true;
-    }
-    if (shouldApplyRemote) {
-      Object.assign(state, remoteState);
-      if (!Number.isFinite(state.updatedAt) || state.updatedAt < remoteUpdatedAtValue) {
-        state.updatedAt = remoteUpdatedAtValue;
-      }
-      ensureStateMeta().remoteUpdatedAt =
-        remoteUpdatedAtIso ||
-        (remoteUpdatedAtValue ? new Date(remoteUpdatedAtValue).toISOString() : null);
-      shouldPersist = true;
-      remoteApplied = true;
-    }
-  } catch (error) {
-    console.error('Nepavyko įkelti nuotolinės būsenos iš Supabase:', error);
-  } finally {
-    if (shouldPersist) {
-      save(state);
-    }
-    maybeAutoOpenAuthModal();
-  }
-  return { appliedRemote: remoteApplied };
+  const remoteResult = await syncLatestRemoteState({ preferRemote: true });
+  maybeAutoOpenAuthModal();
+  return { appliedRemote: Boolean(remoteResult?.applied) };
 }
 
 function resolveAuthErrorMessage(error) {
@@ -851,7 +735,9 @@ function updateAuthSession(session) {
     clearRemoteSaveTimer();
   }
   updateAuthButtonState();
-  updateRemoteSyncButtons();
+  if (authSession && !wasAuthenticated && bootstrapCompleted) {
+    syncLatestRemoteState({ preferRemote: true });
+  }
 }
 
 async function onAuthSignOut() {
@@ -1668,78 +1554,56 @@ function canSyncRemoteState() {
   return supabaseReady && Boolean(authSession?.user);
 }
 
-function ensureRemoteSyncAvailable() {
-  if (!supabaseReady) {
-    alert(T.authNoConfig || 'Supabase konfigūracija nerasta.');
-    return false;
-  }
+async function syncLatestRemoteState(options = {}) {
+  const { preferRemote = false } = options;
   if (!canSyncRemoteState()) {
-    alert(T.remoteSyncAuthRequired || 'Prisijunkite, kad naudotumėte Supabase sinchronizavimą.');
-    return false;
+    return { applied: false };
   }
-  return true;
-}
-
-async function remoteFetchLatest() {
-  if (!ensureRemoteSyncAvailable()) return;
   try {
     setSyncStatus(T.authStatusSyncing || 'Sinchronizuojama…');
     const remote = await fetchSettings();
+    if (!remote) {
+      updateIdleSyncStatus();
+      return { applied: false };
+    }
     const remoteState =
       remote && remote.state_json && typeof remote.state_json === 'object'
         ? remote.state_json
         : null;
-    if (!remoteState) {
-      setSyncStatus(T.remoteSyncNoData || 'Supabase duomenų nerasta.', {
-        variant: 'warning',
-      });
-      return;
-    }
+    const remoteId = typeof remote.id === 'string' && remote.id ? remote.id : null;
     const remoteUpdatedAtIso =
       typeof remote.updated_at === 'string' && remote.updated_at ? remote.updated_at : null;
     const remoteUpdatedAtValue = remoteUpdatedAtIso ? Date.parse(remoteUpdatedAtIso) : null;
     const localUpdatedAt = Number.isFinite(state.updatedAt) ? state.updatedAt : null;
-    const confirmOverwrite = await remoteSyncDialog(T, {
-      remoteUpdatedAt: remoteUpdatedAtValue,
-      localUpdatedAt,
-      isRemoteNewer:
-        Number.isFinite(remoteUpdatedAtValue) &&
-        (!Number.isFinite(localUpdatedAt) || remoteUpdatedAtValue >= localUpdatedAt),
-    });
-    if (!confirmOverwrite) {
-      updateIdleSyncStatus();
-      return;
-    }
-    clearPendingRemoteSave();
-    const remoteId = typeof remote.id === 'string' && remote.id ? remote.id : null;
-    const applied = applyRemoteState(remoteState, {
-      remoteId,
-      remoteUpdatedAtIso,
-      remoteUpdatedAtValue,
-    });
-    if (!applied) {
-      setSyncStatus(T.remoteSyncNoData || 'Supabase duomenų nerasta.', {
-        variant: 'warning',
+    const shouldApply = preferRemote
+      ? Boolean(remoteState)
+      : Number.isFinite(remoteUpdatedAtValue) &&
+        (!Number.isFinite(localUpdatedAt) || remoteUpdatedAtValue >= localUpdatedAt);
+    if (shouldApply && remoteState) {
+      applyRemoteState(remoteState, {
+        remoteId,
+        remoteUpdatedAtIso,
+        remoteUpdatedAtValue,
       });
-      return;
+      setSyncStatus(T.remoteSyncSuccess || 'Duomenys atnaujinti iš Supabase.', {
+        variant: 'success',
+        includeRemoteMeta: true,
+      });
+      return { applied: true };
     }
-    setSyncStatus(T.remoteSyncSuccess || 'Duomenys atnaujinti iš Supabase.', {
-      variant: 'success',
-      includeRemoteMeta: true,
-    });
+    const meta = ensureStateMeta();
+    if (remoteId) meta.remoteId = remoteId;
+    if (remoteUpdatedAtIso) meta.remoteUpdatedAt = remoteUpdatedAtIso;
+    save(state);
+    updateIdleSyncStatus();
+    return { applied: false };
   } catch (error) {
     console.error('Nuotolinio atsisiuntimo klaida iš Supabase:', error);
     setSyncStatus(T.remoteSyncError || 'Nepavyko atsiųsti duomenų iš Supabase.', {
       variant: 'error',
     });
+    return { applied: false, error: true };
   }
-}
-
-async function remotePushLatest() {
-  if (!ensureRemoteSyncAvailable()) return;
-  const snapshot = cloneStateSnapshot(state);
-  if (!snapshot) return;
-  await remoteSave(snapshot);
 }
 
 function applyRemoteState(remoteState, options = {}) {
@@ -2451,113 +2315,6 @@ document.addEventListener('click', (event) => {
     setMenuOpen(false);
   }
 });
-
-let isDataMenuOpen = false;
-let lastFocusedBeforeDataMenu = null;
-
-function focusFirstDataMenuItem() {
-  if (!dataMenuList) return;
-  const focusTarget = dataMenuList.querySelector('button:not([disabled])');
-  if (!(focusTarget instanceof HTMLElement)) return;
-  const focusFn = () => focusTarget.focus();
-  if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
-    window.requestAnimationFrame(focusFn);
-  } else {
-    focusFn();
-  }
-}
-
-function setDataMenuOpenState(open, options = {}) {
-  if (!dataMenu || !dataMenuBtn) return;
-  const { restoreFocus = false } = options;
-  isDataMenuOpen = Boolean(open);
-  dataMenu.dataset.open = open ? '1' : '0';
-  dataMenuBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-  if (!open && restoreFocus) {
-    const focusTarget =
-      lastFocusedBeforeDataMenu instanceof HTMLElement ? lastFocusedBeforeDataMenu : dataMenuBtn;
-    if (focusTarget && typeof focusTarget.focus === 'function') {
-      focusTarget.focus();
-    }
-  }
-  if (!open) {
-    lastFocusedBeforeDataMenu = null;
-  }
-}
-
-function openDataMenu(options = {}) {
-  if (!dataMenu || !dataMenuBtn) return;
-  if (isDataMenuOpen) {
-    if (options.focusFirst) {
-      focusFirstDataMenuItem();
-    }
-    return;
-  }
-  lastFocusedBeforeDataMenu =
-    document.activeElement instanceof HTMLElement ? document.activeElement : dataMenuBtn;
-  setDataMenuOpenState(true);
-  if (options.focusFirst) {
-    focusFirstDataMenuItem();
-  }
-  document.addEventListener('pointerdown', handleDataMenuPointerDown, true);
-  document.addEventListener('focusin', handleDataMenuFocusIn, true);
-  document.addEventListener('keydown', handleDataMenuKeydown, true);
-}
-
-function closeDataMenu(options = {}) {
-  if (!isDataMenuOpen) return;
-  const { restoreFocus = false } = options;
-  setDataMenuOpenState(false, { restoreFocus });
-  document.removeEventListener('pointerdown', handleDataMenuPointerDown, true);
-  document.removeEventListener('focusin', handleDataMenuFocusIn, true);
-  document.removeEventListener('keydown', handleDataMenuKeydown, true);
-}
-
-function toggleDataMenu(options = {}) {
-  if (isDataMenuOpen) {
-    closeDataMenu();
-  } else {
-    openDataMenu(options);
-  }
-}
-
-function handleDataMenuPointerDown(event) {
-  if (!isDataMenuOpen || !dataMenu) return;
-  if (!dataMenu.contains(event.target)) {
-    closeDataMenu();
-  }
-}
-
-function handleDataMenuFocusIn(event) {
-  if (!isDataMenuOpen || !dataMenu) return;
-  if (!dataMenu.contains(event.target)) {
-    closeDataMenu();
-  }
-}
-
-function handleDataMenuKeydown(event) {
-  if (!isDataMenuOpen) return;
-  if (event.key === 'Escape' || event.key === 'Esc') {
-    event.preventDefault();
-    closeDataMenu({ restoreFocus: true });
-  }
-}
-
-if (dataMenu && dataMenuBtn && dataMenuList) {
-  dataMenuBtn.addEventListener('click', () => {
-    toggleDataMenu();
-  });
-  dataMenuBtn.addEventListener('keydown', (event) => {
-    if (event.key === 'ArrowDown' || event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      openDataMenu({ focusFirst: true });
-    } else if (event.key === 'Escape' || event.key === 'Esc') {
-      event.preventDefault();
-      closeDataMenu({ restoreFocus: true });
-    }
-  });
-}
-
 // Išplėtimui: jei reikia kitų laukų ignoravimo, papildykite žemiau esantį sąrašą.
 function isEditableTarget(target) {
   if (!(target instanceof HTMLElement)) return false;
@@ -2664,37 +2421,6 @@ if (addRemindersBtn) {
     addRemindersCard();
   });
 }
-const exportBtnEl = document.getElementById('exportBtn');
-if (exportBtnEl) {
-  exportBtnEl.addEventListener('click', () => {
-    closeDataMenu();
-    exportJson(state);
-  });
-}
-const importBtnEl = document.getElementById('importBtn');
-if (importBtnEl) {
-  importBtnEl.addEventListener('click', () => {
-    closeDataMenu();
-    document.getElementById('fileInput')?.click();
-  });
-}
-if (remoteFetchBtn) {
-  remoteFetchBtn.addEventListener('click', () => {
-    closeDataMenu();
-    remoteFetchLatest();
-  });
-}
-if (remotePushBtn) {
-  remotePushBtn.addEventListener('click', () => {
-    closeDataMenu();
-    remotePushLatest();
-  });
-}
-document.getElementById('fileInput').addEventListener('change', (e) => {
-  const f = e.target.files[0];
-  if (f) importJson(f);
-  e.target.value = '';
-});
 
 window.addEventListener('beforeunload', () => {
   if (authSubscription && typeof authSubscription.unsubscribe === 'function') {

--- a/index.html
+++ b/index.html
@@ -119,90 +119,6 @@
         <button id="editBtn" class="btn-outline" type="button">
           Redaguoti
         </button>
-        <div
-          id="dataMenu"
-          class="data-menu"
-          data-open="0"
-          data-editing-visible
-        >
-          <button
-            id="dataMenuBtn"
-            class="btn-outline data-menu-toggle"
-            type="button"
-            aria-haspopup="true"
-            aria-expanded="false"
-            aria-controls="dataMenuList"
-          >
-            <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-              <path
-                d="M4 22h16a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2h-7.59a2 2 0 0 1-1.41-.59L9.59 1.41A2 2 0 0 0 8.17 1H4a2 2 0 0 0-2 2v17a2 2 0 0 0 2 2z"
-              />
-            </svg>
-            <span data-menu-label>Duomenys</span>
-            <svg class="chevron" viewBox="0 0 24 24" aria-hidden="true">
-              <polyline points="6 9 12 15 18 9" />
-            </svg>
-          </button>
-          <div
-            id="dataMenuList"
-            class="menu-panel"
-            role="menu"
-            aria-labelledby="dataMenuBtn"
-          >
-            <button
-              id="importBtn"
-              type="button"
-              role="menuitem"
-              data-menu-import
-            >
-              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-                <polyline points="7 10 12 15 17 10" />
-                <line x1="12" y1="15" x2="12" y2="3" />
-              </svg>
-              <span>Importuoti</span>
-            </button>
-            <button
-              id="exportBtn"
-              type="button"
-              role="menuitem"
-              data-menu-export
-            >
-              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-                <polyline points="17 8 12 3 7 8" />
-                <line x1="12" y1="3" x2="12" y2="15" />
-              </svg>
-              <span>Eksportuoti</span>
-            </button>
-            <button
-              id="remoteFetchBtn"
-              type="button"
-              role="menuitem"
-              data-menu-remote-fetch
-            >
-              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M7 19a4 4 0 110-8 5 5 0 019.42-1.74A4 4 0 1118 19H7z" />
-                <polyline points="12 6 12 15 9 12" />
-                <polyline points="12 15 15 12" />
-              </svg>
-              <span>Atsiųsti iš Supabase</span>
-            </button>
-            <button
-              id="remotePushBtn"
-              type="button"
-              role="menuitem"
-              data-menu-remote-push
-            >
-              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M7 19a4 4 0 110-8 5 5 0 019.42-1.74A4 4 0 1118 19H7z" />
-                <polyline points="12 18 12 9 15 12" />
-                <polyline points="12 9 9 12" />
-              </svg>
-              <span>Išsiųsti į Supabase</span>
-            </button>
-          </div>
-        </div>
         <button
           id="themeBtn"
           class="btn"
@@ -236,7 +152,6 @@
       <div id="groups" class="grid" aria-live="polite"></div>
     </main>
 
-    <input type="file" id="fileInput" accept="application/json" hidden />
     <input
       type="file"
       id="pageIconFile"


### PR DESCRIPTION
## Summary
- remove the manual data menu and JSON import/export controls to simplify the header
- load the latest Supabase state automatically when a session is available and sync changes in the background
- document the automatic cloud sync behavior and update privacy notes

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e1bb51e0c8320af5e42ef3ef8b679)