### PR TITLE
Ensure remote sync respects newer local changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ Statinis HTML + ES moduliais paremtas prietaisų skydas, skirtas greitam informa
   2. Jei reikia papildomos atsarginės kopijos, `app.js` faile atkomentuokite `const sheets = sheetsSync(...)` ir iškvieskite `sheets.export()`/`sheets.import()` savo logikoje.
   3. Apps Script turėtų palaikyti `action: "export" | "import"` ir grąžinti JSON struktūrą, atitinkančią `storage.js` tipą.
 
+### Rankinis duomenų atkūrimas / eksportas
+- Viršutinėje juostoje yra meniu **„Duomenys“**: importuoti JSON, eksportuoti, atsisiųsti iš Supabase arba išsiųsti į Supabase.
+- Jei Supabase įrašas buvo tuščias, importuokite atsarginį `.json` failą ir spauskite „Išsiųsti į Supabase“ (reikalingas prisijungimas), kad atstatytumėte nuotolinę kopiją.
+
 ## Privatumas ir leidimai
 - Primenimų pranešimai gali būti matomi užrakintame įrenginyje – prieš įjungdami įsitikinkite, kad tai leidžia skyriuje galiojančios taisyklės.
 - Visa informacija išlieka vartotojo naršyklėje; jei Supabase konfigūruotas ir esate prisijungę, duomenys automatiškai siunčiami į Supabase kaip atsarginė kopija.

--- a/app.js
+++ b/app.js
@@ -1592,6 +1592,21 @@ function canSyncRemoteState() {
   return supabaseReady && Boolean(authSession?.user);
 }
 
+function parseRemoteState(input) {
+  if (!input) return null;
+  if (typeof input === 'object') return input;
+  if (typeof input === 'string') {
+    try {
+      const parsed = JSON.parse(input);
+      return parsed && typeof parsed === 'object' ? parsed : null;
+    } catch (error) {
+      console.warn('Nepavyko perskaityti Supabase state_json kaip JSON:', error);
+      return null;
+    }
+  }
+  return null;
+}
+
 function hasLocalContent() {
   const hasGroups = Array.isArray(state?.groups) && state.groups.length > 0;
   const hasCustomReminders =
@@ -1616,10 +1631,7 @@ async function syncLatestRemoteState(options = {}) {
       updateIdleSyncStatus();
       return { applied: false };
     }
-    const remoteState =
-      remote && remote.state_json && typeof remote.state_json === 'object'
-        ? remote.state_json
-        : null;
+    const remoteState = parseRemoteState(remote?.state_json);
     const remoteId = typeof remote.id === 'string' && remote.id ? remote.id : null;
     const remoteUpdatedAtIso =
       typeof remote.updated_at === 'string' && remote.updated_at ? remote.updated_at : null;
@@ -1834,6 +1846,9 @@ export const __testHooks = {
   setStateForTest(nextState) {
     state = nextState;
   },
+  getStateForTest() {
+    return state;
+  },
   setAuthSessionForTest(session) {
     authSession = session;
   },
@@ -1852,6 +1867,9 @@ export const __testHooks = {
   },
   async flushRemoteSaveForTest(snapshot) {
     await remoteSave(snapshot);
+  },
+  syncLatestRemoteStateForTest(options) {
+    return syncLatestRemoteState(options);
   },
 };
 

--- a/app.js
+++ b/app.js
@@ -1663,6 +1663,15 @@ async function syncLatestRemoteState(options = {}) {
       });
       return { applied: true };
     }
+    console.info('Supabase sync praleistas', {
+      preferRemote,
+      remoteStatePresent: Boolean(remoteState),
+      remoteUpdatedAtIso,
+      remoteHasTimestamp,
+      localHasContent,
+      localUpdatedAt,
+      remoteIsNewerOrEqual,
+    });
     const meta = ensureStateMeta();
     if (remoteId) meta.remoteId = remoteId;
     if (remoteUpdatedAtIso) meta.remoteUpdatedAt = remoteUpdatedAtIso;

--- a/app.js
+++ b/app.js
@@ -1599,7 +1599,7 @@ function parseRemoteState(input) {
 
   let current = input;
   let attempts = 0;
-  while (typeof current === 'string' && attempts < 2) {
+  while (typeof current === 'string' && attempts < 5) {
     try {
       current = JSON.parse(current);
       attempts += 1;

--- a/app.js
+++ b/app.js
@@ -1613,10 +1613,13 @@ async function syncLatestRemoteState(options = {}) {
       typeof remote.updated_at === 'string' && remote.updated_at ? remote.updated_at : null;
     const remoteUpdatedAtValue = remoteUpdatedAtIso ? Date.parse(remoteUpdatedAtIso) : null;
     const localUpdatedAt = Number.isFinite(state.updatedAt) ? state.updatedAt : null;
-    const shouldApply = preferRemote
-      ? Boolean(remoteState)
-      : Number.isFinite(remoteUpdatedAtValue) &&
-        (!Number.isFinite(localUpdatedAt) || remoteUpdatedAtValue >= localUpdatedAt);
+    const remoteHasTimestamp = Number.isFinite(remoteUpdatedAtValue);
+    const remoteIsNewerOrEqual =
+      remoteHasTimestamp && (!Number.isFinite(localUpdatedAt) || remoteUpdatedAtValue >= localUpdatedAt);
+    const shouldApply = Boolean(remoteState) &&
+      (preferRemote
+        ? remoteIsNewerOrEqual || !remoteHasTimestamp
+        : remoteIsNewerOrEqual);
     if (shouldApply && remoteState) {
       applyRemoteState(remoteState, {
         remoteId,

--- a/app.js
+++ b/app.js
@@ -39,6 +39,7 @@ import {
   hasReminderPayload,
 } from './reminder-input.js';
 import { getActiveTheme, resolveChartThemeUrl } from './theme-utils.js';
+import { exportJson } from './exporter.js';
 
 const T = Tlt;
 // Hook future English localisation: fill T.en when translations are ready.
@@ -223,6 +224,15 @@ const addMenu = document.getElementById('addMenu');
 const addMenuList = document.getElementById('addMenuList');
 const addBtn = document.getElementById('addBtn');
 const addMenuBackdrop = addMenu?.querySelector('[data-menu-backdrop]') ?? null;
+const dataMenu = document.getElementById('dataMenu');
+const dataMenuList = document.getElementById('dataMenuList');
+const dataBtn = document.getElementById('dataBtn');
+const dataMenuBackdrop = dataMenu?.querySelector('[data-menu-backdrop]') ?? null;
+const dataImportBtn = document.getElementById('dataImport');
+const dataExportBtn = document.getElementById('dataExport');
+const dataRemoteFetchBtn = document.getElementById('dataRemoteFetch');
+const dataRemotePushBtn = document.getElementById('dataRemotePush');
+const dataFileInput = document.getElementById('dataFileInput');
 const helpBtn = document.getElementById('helpBtn');
 const searchClearBtn = document.getElementById('searchClear');
 const pageIconImageBtn = document.getElementById('pageIconImageBtn');
@@ -242,6 +252,7 @@ let loginGateDelayTimer = null;
 let loginGateDelayUsed = false;
 
 applyPageIconActionLabels();
+applyDataMenuLabels();
 applyAuthLabels();
 updateAuthButtonState();
 
@@ -256,6 +267,18 @@ if (addBtn) {
     addBtn.setAttribute('aria-haspopup', 'true');
   }
   addBtn.setAttribute('aria-expanded', addMenu?.dataset.open === '1' ? 'true' : 'false');
+}
+if (dataMenu && !dataMenu.dataset.open) {
+  dataMenu.dataset.open = '0';
+}
+if (dataBtn) {
+  if (!dataBtn.hasAttribute('aria-controls')) {
+    dataBtn.setAttribute('aria-controls', 'dataMenuList');
+  }
+  if (!dataBtn.hasAttribute('aria-haspopup')) {
+    dataBtn.setAttribute('aria-haspopup', 'true');
+  }
+  dataBtn.setAttribute('aria-expanded', dataMenu?.dataset.open === '1' ? 'true' : 'false');
 }
 let state = load() || seed();
 bootstrapSession()
@@ -374,6 +397,25 @@ const updateSearchClearVisibility = () => {
   const hasValue = Boolean(searchEl?.value?.trim());
   searchClearBtn.hidden = !hasValue;
 };
+
+function applyDataMenuLabels() {
+  if (dataBtn) {
+    dataBtn.textContent = T.dataMenu || 'Duomenys';
+    dataBtn.setAttribute('aria-label', T.dataMenu || 'Duomenys');
+  }
+  if (dataImportBtn) {
+    dataImportBtn.textContent = T.import || 'Importuoti';
+  }
+  if (dataExportBtn) {
+    dataExportBtn.textContent = T.export || 'Eksportuoti';
+  }
+  if (dataRemoteFetchBtn) {
+    dataRemoteFetchBtn.textContent = T.remoteFetch || 'Atsiųsti iš Supabase';
+  }
+  if (dataRemotePushBtn) {
+    dataRemotePushBtn.textContent = T.remotePush || 'Išsiųsti į Supabase';
+  }
+}
 
 function applyPageIconActionLabels() {
   if (pageIconImageBtn) {
@@ -1612,15 +1654,16 @@ function parseRemoteState(input) {
   return current && typeof current === 'object' ? current : null;
 }
 
-function hasLocalContent() {
-  const hasGroups = Array.isArray(state?.groups) && state.groups.length > 0;
+function hasContentSnapshot(target = state) {
+  if (!target || typeof target !== 'object') return false;
+  const hasGroups = Array.isArray(target?.groups) && target.groups.length > 0;
   const hasCustomReminders =
-    Array.isArray(state?.customReminders) && state.customReminders.length > 0;
-  const hasTitle = typeof state?.title === 'string' && state.title.trim().length > 0;
+    Array.isArray(target?.customReminders) && target.customReminders.length > 0;
+  const hasTitle = typeof target?.title === 'string' && target.title.trim().length > 0;
   const hasIcon =
-    (typeof state?.icon === 'string' && state.icon.trim()) ||
-    (typeof state?.iconImage === 'string' && state.iconImage.trim());
-  const remindersEnabled = Boolean(state?.remindersCard?.enabled);
+    (typeof target?.icon === 'string' && target.icon.trim()) ||
+    (typeof target?.iconImage === 'string' && target.iconImage.trim());
+  const remindersEnabled = Boolean(target?.remindersCard?.enabled);
   return hasGroups || hasCustomReminders || hasTitle || hasIcon || remindersEnabled;
 }
 
@@ -1641,13 +1684,15 @@ async function syncLatestRemoteState(options = {}) {
     const remoteUpdatedAtIso =
       typeof remote.updated_at === 'string' && remote.updated_at ? remote.updated_at : null;
     const remoteUpdatedAtValue = remoteUpdatedAtIso ? Date.parse(remoteUpdatedAtIso) : null;
-    const localHasContent = hasLocalContent();
+    const remoteHasContent = hasContentSnapshot(remoteState);
+    const localHasContent = hasContentSnapshot(state);
     const localUpdatedAt =
       localHasContent && Number.isFinite(state.updatedAt) ? state.updatedAt : null;
     const remoteHasTimestamp = Number.isFinite(remoteUpdatedAtValue);
     const remoteIsNewerOrEqual =
       remoteHasTimestamp && (!Number.isFinite(localUpdatedAt) || remoteUpdatedAtValue >= localUpdatedAt);
     const shouldApply = Boolean(remoteState) &&
+      remoteHasContent &&
       (preferRemote
         ? remoteIsNewerOrEqual || !remoteHasTimestamp || !localHasContent
         : remoteIsNewerOrEqual);
@@ -1666,12 +1711,16 @@ async function syncLatestRemoteState(options = {}) {
     console.info('Supabase sync praleistas', {
       preferRemote,
       remoteStatePresent: Boolean(remoteState),
+      remoteHasContent,
       remoteUpdatedAtIso,
       remoteHasTimestamp,
       localHasContent,
       localUpdatedAt,
       remoteIsNewerOrEqual,
     });
+    if (remoteState && !remoteHasContent) {
+      setSyncStatus(T.remoteSyncNoData || 'Supabase duomenų nerasta.', { variant: 'warning' });
+    }
     const meta = ensureStateMeta();
     if (remoteId) meta.remoteId = remoteId;
     if (remoteUpdatedAtIso) meta.remoteUpdatedAt = remoteUpdatedAtIso;
@@ -1685,6 +1734,40 @@ async function syncLatestRemoteState(options = {}) {
     });
     return { applied: false, error: true };
   }
+}
+
+async function manualRemoteFetch() {
+  setDataMenuOpen(false);
+  if (!canSyncRemoteState()) {
+    alert(T.remoteSyncAuthRequired || 'Prisijunkite, kad naudotumėte Supabase sinchronizavimą.');
+    return;
+  }
+  const hasLocal = hasContentSnapshot(state);
+  if (hasLocal) {
+    const confirmed = window.confirm(
+      T.remoteSyncDialogDescription || 'Nuotoliniai duomenys gali perrašyti vietinius įrašus. Patvirtinkite veiksmą.',
+    );
+    if (!confirmed) return;
+  }
+  const result = await syncLatestRemoteState({ preferRemote: true });
+  if (!result.applied) {
+    setSyncStatus(T.remoteSyncNoData || 'Supabase duomenų nerasta.', { variant: 'warning' });
+  }
+}
+
+async function manualRemotePush() {
+  setDataMenuOpen(false);
+  if (!canSyncRemoteState()) {
+    alert(T.remoteSyncAuthRequired || 'Prisijunkite, kad naudotumėte Supabase sinchronizavimą.');
+    return;
+  }
+  if (!hasContentSnapshot(state)) {
+    alert(T.remotePushEmpty || 'Nėra ką siųsti – skydelis tuščias.');
+    return;
+  }
+  setSyncStatus(T.remotePushProgress || 'Siunčiama į Supabase…');
+  await remoteSave(cloneStateSnapshot(state));
+  setSyncStatus(T.remotePushSuccess || 'Duomenys įkelti į Supabase.', { variant: 'success' });
 }
 
 function applyRemoteState(remoteState, options = {}) {
@@ -2334,6 +2417,10 @@ function isMenuOpen() {
   return addMenu?.dataset.open === '1';
 }
 
+function isDataMenuOpen() {
+  return dataMenu?.dataset.open === '1';
+}
+
 function setMenuOpen(open, options = {}) {
   if (!addMenu) return;
   const { restoreFocus = true } = options;
@@ -2378,11 +2465,39 @@ function setMenuOpen(open, options = {}) {
   }
 }
 
+function setDataMenuOpen(open) {
+  if (!dataMenu) return;
+  const currentlyOpen = isDataMenuOpen();
+  if (open === currentlyOpen) return;
+  dataMenu.dataset.open = open ? '1' : '0';
+  if (dataBtn) {
+    dataBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+  }
+
+  if (open) {
+    const focusTarget = dataMenuList?.querySelector('button:not([disabled])');
+    if (focusTarget instanceof HTMLElement && typeof focusTarget.focus === 'function') {
+      focusTarget.focus();
+    }
+    document.addEventListener('keydown', handleDataMenuKeydown);
+  } else {
+    document.removeEventListener('keydown', handleDataMenuKeydown);
+  }
+}
+
 function handleMenuKeydown(event) {
   if (!isMenuOpen()) return;
   if (event.key === 'Escape' || event.key === 'Esc') {
     event.preventDefault();
     setMenuOpen(false);
+  }
+}
+
+function handleDataMenuKeydown(event) {
+  if (!isDataMenuOpen()) return;
+  if (event.key === 'Escape' || event.key === 'Esc') {
+    event.preventDefault();
+    setDataMenuOpen(false);
   }
 }
 
@@ -2402,6 +2517,62 @@ document.addEventListener('click', (event) => {
     setMenuOpen(false);
   }
 });
+
+if (dataBtn && dataMenu) {
+  dataBtn.addEventListener('click', () => {
+    setDataMenuOpen(!isDataMenuOpen());
+  });
+}
+
+if (dataMenuBackdrop) {
+  dataMenuBackdrop.addEventListener('click', () => setDataMenuOpen(false));
+}
+
+document.addEventListener('click', (event) => {
+  if (!dataMenu || !isDataMenuOpen()) return;
+  if (!dataMenu.contains(event.target)) {
+    setDataMenuOpen(false);
+  }
+});
+
+if (dataImportBtn && dataFileInput) {
+  dataImportBtn.addEventListener('click', () => {
+    dataFileInput.value = '';
+    dataFileInput.click();
+  });
+}
+
+if (dataFileInput) {
+  dataFileInput.addEventListener('change', (event) => {
+    const target = event.target;
+    const file = target?.files?.[0];
+    if (file) {
+      importJson(file);
+      setSyncStatus(T.remoteImportSuccess || 'Failas importuotas.');
+    }
+    if (target) target.value = '';
+    setDataMenuOpen(false);
+  });
+}
+
+if (dataExportBtn) {
+  dataExportBtn.addEventListener('click', () => {
+    exportJson(state);
+    setDataMenuOpen(false);
+  });
+}
+
+if (dataRemoteFetchBtn) {
+  dataRemoteFetchBtn.addEventListener('click', () => {
+    manualRemoteFetch();
+  });
+}
+
+if (dataRemotePushBtn) {
+  dataRemotePushBtn.addEventListener('click', () => {
+    manualRemotePush();
+  });
+}
 // Išplėtimui: jei reikia kitų laukų ignoravimo, papildykite žemiau esantį sąrašą.
 function isEditableTarget(target) {
   if (!(target instanceof HTMLElement)) return false;

--- a/app.js
+++ b/app.js
@@ -1592,6 +1592,18 @@ function canSyncRemoteState() {
   return supabaseReady && Boolean(authSession?.user);
 }
 
+function hasLocalContent() {
+  const hasGroups = Array.isArray(state?.groups) && state.groups.length > 0;
+  const hasCustomReminders =
+    Array.isArray(state?.customReminders) && state.customReminders.length > 0;
+  const hasTitle = typeof state?.title === 'string' && state.title.trim().length > 0;
+  const hasIcon =
+    (typeof state?.icon === 'string' && state.icon.trim()) ||
+    (typeof state?.iconImage === 'string' && state.iconImage.trim());
+  const remindersEnabled = Boolean(state?.remindersCard?.enabled);
+  return hasGroups || hasCustomReminders || hasTitle || hasIcon || remindersEnabled;
+}
+
 async function syncLatestRemoteState(options = {}) {
   const { preferRemote = false } = options;
   if (!canSyncRemoteState()) {
@@ -1616,9 +1628,10 @@ async function syncLatestRemoteState(options = {}) {
     const remoteHasTimestamp = Number.isFinite(remoteUpdatedAtValue);
     const remoteIsNewerOrEqual =
       remoteHasTimestamp && (!Number.isFinite(localUpdatedAt) || remoteUpdatedAtValue >= localUpdatedAt);
+    const localHasContent = hasLocalContent();
     const shouldApply = Boolean(remoteState) &&
       (preferRemote
-        ? remoteIsNewerOrEqual || !remoteHasTimestamp
+        ? remoteIsNewerOrEqual || !remoteHasTimestamp || !localHasContent
         : remoteIsNewerOrEqual);
     if (shouldApply && remoteState) {
       applyRemoteState(remoteState, {

--- a/app.js
+++ b/app.js
@@ -1595,16 +1595,21 @@ function canSyncRemoteState() {
 function parseRemoteState(input) {
   if (!input) return null;
   if (typeof input === 'object') return input;
-  if (typeof input === 'string') {
+  if (typeof input !== 'string') return null;
+
+  let current = input;
+  let attempts = 0;
+  while (typeof current === 'string' && attempts < 2) {
     try {
-      const parsed = JSON.parse(input);
-      return parsed && typeof parsed === 'object' ? parsed : null;
+      current = JSON.parse(current);
+      attempts += 1;
     } catch (error) {
       console.warn('Nepavyko perskaityti Supabase state_json kaip JSON:', error);
       return null;
     }
   }
-  return null;
+
+  return current && typeof current === 'object' ? current : null;
 }
 
 function hasLocalContent() {

--- a/app.js
+++ b/app.js
@@ -1624,11 +1624,12 @@ async function syncLatestRemoteState(options = {}) {
     const remoteUpdatedAtIso =
       typeof remote.updated_at === 'string' && remote.updated_at ? remote.updated_at : null;
     const remoteUpdatedAtValue = remoteUpdatedAtIso ? Date.parse(remoteUpdatedAtIso) : null;
-    const localUpdatedAt = Number.isFinite(state.updatedAt) ? state.updatedAt : null;
+    const localHasContent = hasLocalContent();
+    const localUpdatedAt =
+      localHasContent && Number.isFinite(state.updatedAt) ? state.updatedAt : null;
     const remoteHasTimestamp = Number.isFinite(remoteUpdatedAtValue);
     const remoteIsNewerOrEqual =
       remoteHasTimestamp && (!Number.isFinite(localUpdatedAt) || remoteUpdatedAtValue >= localUpdatedAt);
-    const localHasContent = hasLocalContent();
     const shouldApply = Boolean(remoteState) &&
       (preferRemote
         ? remoteIsNewerOrEqual || !remoteHasTimestamp || !localHasContent

--- a/docs/supabase-integration-plan.md
+++ b/docs/supabase-integration-plan.md
@@ -75,7 +75,7 @@
 - **Tikslas:** Vartotojas turi matyti, kada paskutinį kartą sinchronizuota, ir galėti importuoti/išeksportuoti į Supabase.
 - **Failai:**
   - `app.js`/`forms.js` – `Duomenų` meniu pridėkite mygtukus „Atsiųsti iš Supabase“ (`remoteFetchButton`) ir „Išsiųsti į Supabase“ (`remotePushButton`).
-  - `render.js` – atnaujinkite `syncStatus` rodmenis: `Paskutinė nuotolinė sinchronizacija: 14:32`.
+- `render.js` – atnaujinkite `syncStatus` rodmenis: `Atnaujinta: 14:32`.
   - `app.js` – `remoteFetch()` turi parodyti modalą su pasirinkimu „Perrašyti vietinius duomenis“ arba „Atšaukti“.
 - **Logika:** konfliktus spręskite paprastai – jei nuotoliniai duomenys naujesni (`remote.updated_at > state.updatedAt`), rodykite įspėjimą su `confirm()` ir tik sutikus perrašykite.
 - **Smoke test:** keiskite būseną dviejuose naršyklės languose ir patikrinkite, kad rankinis „Atsiųsti“ atnaujintų duomenis.

--- a/i18n.js
+++ b/i18n.js
@@ -11,6 +11,10 @@ export const Tlt = {
   dataMenu: 'Duomenys',
   remoteFetch: 'Atsiųsti iš Supabase',
   remotePush: 'Išsiųsti į Supabase',
+  remotePushProgress: 'Siunčiama į Supabase…',
+  remotePushSuccess: 'Duomenys įkelti į Supabase.',
+  remotePushEmpty: 'Nėra ką siųsti – skydelis tuščias.',
+  remoteImportSuccess: 'Failas importuotas.',
   remoteSyncDialogTitle: 'Atsiųsti iš Supabase',
   remoteSyncDialogDescription:
     'Nuotoliniai duomenys gali perrašyti vietinius įrašus. Patvirtinkite veiksmą.',

--- a/i18n.js
+++ b/i18n.js
@@ -24,7 +24,7 @@ export const Tlt = {
   remoteSyncError: 'Nepavyko atsiųsti duomenų iš Supabase.',
   remoteSyncSuccess: 'Duomenys atnaujinti iš Supabase.',
   remoteSyncAuthRequired: 'Prisijunkite, kad naudotumėte Supabase sinchronizavimą.',
-  remoteSyncLast: 'Paskutinė nuotolinė sinchronizacija: {time}',
+  remoteSyncLast: 'Atnaujinta: {time}',
   theme: 'Tema',
   color: 'Spalva',
   customize: 'Tinkinti',

--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
         </div>
       </div>
       <div class="secondary-actions" data-zone="secondary-actions">
-        <div id="dataMenu" data-open="0">
+        <div id="dataMenu" class="data-menu" data-open="0">
           <button
             id="dataBtn"
             class="btn-outline"

--- a/index.html
+++ b/index.html
@@ -115,6 +115,34 @@
         </div>
       </div>
       <div class="secondary-actions" data-zone="secondary-actions">
+        <div id="dataMenu" data-open="0">
+          <button
+            id="dataBtn"
+            class="btn-outline"
+            type="button"
+            aria-haspopup="true"
+            aria-expanded="false"
+            aria-controls="dataMenuList"
+          >
+            Duomenys
+          </button>
+          <div class="menu-backdrop" data-menu-backdrop aria-hidden="true"></div>
+          <div
+            id="dataMenuList"
+            class="menu-panel"
+            role="menu"
+            aria-labelledby="dataBtn"
+          >
+            <button id="dataImport" type="button" role="menuitem">📥 Importuoti</button>
+            <button id="dataExport" type="button" role="menuitem">📤 Eksportuoti</button>
+            <button id="dataRemoteFetch" type="button" role="menuitem">
+              ⇣ Atsiųsti iš Supabase
+            </button>
+            <button id="dataRemotePush" type="button" role="menuitem">
+              ⇡ Išsiųsti į Supabase
+            </button>
+          </div>
+        </div>
         <!-- Fallback labels so buttons are visible before JS initializes -->
         <button id="editBtn" class="btn-outline" type="button">
           Redaguoti
@@ -158,6 +186,8 @@
       accept="image/png,image/jpeg,image/gif,image/webp,image/svg+xml"
       hidden
     />
+
+    <input type="file" id="dataFileInput" accept="application/json" hidden />
 
     <div
       id="authModal"

--- a/render.js
+++ b/render.js
@@ -23,7 +23,7 @@ export function formatRemoteSyncStatus(meta, T = {}) {
       .toString()
       .padStart(2, '0')}`;
   }
-  const template = T.remoteSyncLast || 'Paskutinė nuotolinė sinchronizacija: {time}';
+  const template = T.remoteSyncLast || 'Atnaujinta: {time}';
   return template.replace('{time}', timeLabel);
 }
 

--- a/supabase-client.js
+++ b/supabase-client.js
@@ -113,7 +113,9 @@ export async function fetchSettings() {
   const { data, error } = await client
     .from('ed_dash_settings')
     .select('id, user_id, state_json, updated_at')
-    .single();
+    .order('updated_at', { ascending: false, nullsLast: true })
+    .limit(1)
+    .maybeSingle();
   if (error) {
     if (error.code === 'PGRST116') {
       return null;

--- a/tests/supabase-sync.test.js
+++ b/tests/supabase-sync.test.js
@@ -36,7 +36,7 @@ function createStubElement() {
     appendChild: noop,
     remove: noop,
     classList: { add: noop, remove: noop, toggle: noop, contains: () => false },
-    style: {},
+    style: { setProperty: noop },
     focus: noop,
     blur: noop,
     click: noop,
@@ -155,5 +155,42 @@ test('persistState kviečia nuotolinį išsaugojimą, kai vartotojas prisijungę
     assert.equal(supabaseCalls.upsert, 1);
   } finally {
     supabaseCalls.upsert = 0;
+  }
+});
+
+test('syncLatestRemoteState parsiunčia string state_json su preferRemote', async () => {
+  const originalFetch = supabaseMock.fetchSettings;
+  const remoteSnapshot = {
+    ...createMinimalState(),
+    groups: [{ id: 'g-1', title: 'Nuotolinis', items: [] }],
+    title: 'Nuotolinis pavadinimas',
+    updatedAt: Date.now() - 5_000,
+  };
+  supabaseMock.fetchSettings = async () => ({
+    id: 'row-2',
+    user_id: 'user-2',
+    state_json: JSON.stringify(remoteSnapshot),
+    updated_at: new Date(remoteSnapshot.updatedAt).toISOString(),
+  });
+
+  try {
+    const app = await loadAppModule();
+    const hooks = app.__testHooks;
+    hooks.setSupabaseReadyForTest(true);
+    hooks.setAuthSessionForTest({ user: { id: 'user-2', email: 'remote@example.com' } });
+    hooks.setStateForTest({
+      ...createMinimalState(),
+      updatedAt: Date.now(),
+      meta: {},
+    });
+
+    const result = await hooks.syncLatestRemoteStateForTest({ preferRemote: true });
+    assert.equal(result.applied, true);
+    const nextState = hooks.getStateForTest();
+    assert.equal(nextState.title, remoteSnapshot.title);
+    assert.deepEqual(nextState.groups, remoteSnapshot.groups);
+    assert.equal(nextState.meta.remoteId, 'row-2');
+  } finally {
+    supabaseMock.fetchSettings = originalFetch;
   }
 });

--- a/tests/supabase-sync.test.js
+++ b/tests/supabase-sync.test.js
@@ -194,3 +194,40 @@ test('syncLatestRemoteState parsiunčia string state_json su preferRemote', asyn
     supabaseMock.fetchSettings = originalFetch;
   }
 });
+
+test('syncLatestRemoteState išskleidžia dvigubai užkoduotą state_json', async () => {
+  const originalFetch = supabaseMock.fetchSettings;
+  const remoteSnapshot = {
+    ...createMinimalState(),
+    groups: [{ id: 'g-9', title: 'Dviguba', items: [] }],
+    title: 'Dvigubai užkoduota',
+    updatedAt: Date.now() - 10_000,
+  };
+  supabaseMock.fetchSettings = async () => ({
+    id: 'row-9',
+    user_id: 'user-9',
+    state_json: JSON.stringify(JSON.stringify(remoteSnapshot)),
+    updated_at: new Date(remoteSnapshot.updatedAt).toISOString(),
+  });
+
+  try {
+    const app = await loadAppModule();
+    const hooks = app.__testHooks;
+    hooks.setSupabaseReadyForTest(true);
+    hooks.setAuthSessionForTest({ user: { id: 'user-9', email: 'double@example.com' } });
+    hooks.setStateForTest({
+      ...createMinimalState(),
+      updatedAt: Date.now(),
+      meta: {},
+    });
+
+    const result = await hooks.syncLatestRemoteStateForTest({ preferRemote: true });
+    assert.equal(result.applied, true);
+    const nextState = hooks.getStateForTest();
+    assert.equal(nextState.title, remoteSnapshot.title);
+    assert.deepEqual(nextState.groups, remoteSnapshot.groups);
+    assert.equal(nextState.meta.remoteId, 'row-9');
+  } finally {
+    supabaseMock.fetchSettings = originalFetch;
+  }
+});

--- a/tests/supabase-sync.test.js
+++ b/tests/supabase-sync.test.js
@@ -231,3 +231,40 @@ test('syncLatestRemoteState išskleidžia dvigubai užkoduotą state_json', asyn
     supabaseMock.fetchSettings = originalFetch;
   }
 });
+
+test('syncLatestRemoteState išskleidžia trigubai užkoduotą state_json', async () => {
+  const originalFetch = supabaseMock.fetchSettings;
+  const remoteSnapshot = {
+    ...createMinimalState(),
+    groups: [{ id: 'g-10', title: 'Triguba', items: [] }],
+    title: 'Trigubai užkoduota',
+    updatedAt: Date.now() - 15_000,
+  };
+  supabaseMock.fetchSettings = async () => ({
+    id: 'row-10',
+    user_id: 'user-10',
+    state_json: JSON.stringify(JSON.stringify(JSON.stringify(remoteSnapshot))),
+    updated_at: new Date(remoteSnapshot.updatedAt).toISOString(),
+  });
+
+  try {
+    const app = await loadAppModule();
+    const hooks = app.__testHooks;
+    hooks.setSupabaseReadyForTest(true);
+    hooks.setAuthSessionForTest({ user: { id: 'user-10', email: 'triple@example.com' } });
+    hooks.setStateForTest({
+      ...createMinimalState(),
+      updatedAt: Date.now(),
+      meta: {},
+    });
+
+    const result = await hooks.syncLatestRemoteStateForTest({ preferRemote: true });
+    assert.equal(result.applied, true);
+    const nextState = hooks.getStateForTest();
+    assert.equal(nextState.title, remoteSnapshot.title);
+    assert.deepEqual(nextState.groups, remoteSnapshot.groups);
+    assert.equal(nextState.meta.remoteId, 'row-10');
+  } finally {
+    supabaseMock.fetchSettings = originalFetch;
+  }
+});

--- a/tests/supabase-sync.test.js
+++ b/tests/supabase-sync.test.js
@@ -40,6 +40,7 @@ function createStubElement() {
     focus: noop,
     blur: noop,
     click: noop,
+    dataset: {},
     value: '',
     innerHTML: '',
     textContent: '',
@@ -264,6 +265,38 @@ test('syncLatestRemoteState išskleidžia trigubai užkoduotą state_json', asyn
     assert.equal(nextState.title, remoteSnapshot.title);
     assert.deepEqual(nextState.groups, remoteSnapshot.groups);
     assert.equal(nextState.meta.remoteId, 'row-10');
+  } finally {
+    supabaseMock.fetchSettings = originalFetch;
+  }
+});
+
+test('syncLatestRemoteState nepritaiko tuščio remote snapshot preferRemote režimu', async () => {
+  const originalFetch = supabaseMock.fetchSettings;
+  supabaseMock.fetchSettings = async () => ({
+    id: 'row-empty',
+    user_id: 'user-empty',
+    state_json: '{}',
+    updated_at: new Date().toISOString(),
+  });
+
+  try {
+    const app = await loadAppModule();
+    const hooks = app.__testHooks;
+    hooks.setSupabaseReadyForTest(true);
+    hooks.setAuthSessionForTest({ user: { id: 'user-empty', email: 'empty@example.com' } });
+    hooks.setStateForTest({
+      ...createMinimalState(),
+      title: 'Lokalus',
+      groups: [{ id: 'g-local', title: 'Lokalus', items: [] }],
+      updatedAt: Date.now(),
+      meta: {},
+    });
+
+    const result = await hooks.syncLatestRemoteStateForTest({ preferRemote: true });
+    assert.equal(result.applied, false);
+    const nextState = hooks.getStateForTest();
+    assert.equal(nextState.title, 'Lokalus');
+    assert.deepEqual(nextState.groups, [{ id: 'g-local', title: 'Lokalus', items: [] }]);
   } finally {
     supabaseMock.fetchSettings = originalFetch;
   }


### PR DESCRIPTION
## Summary
- guard syncLatestRemoteState so preferRemote no longer overwrites newer local state with older cloud data
- apply remote snapshots when timestamps indicate newer data or no remote timestamp is provided

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ef5504f108320acb0224df07d80a8)